### PR TITLE
Support xsd's which bind the xmlschema namespace to the root instead of to 'xs'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    xsd-reader (0.1.0)
+    xsd-reader (0.3.0)
       nokogiri (~> 1.6)
       rest-client (~> 1.8)
 
@@ -12,15 +12,15 @@ GEM
       columnize (= 0.9.0)
     columnize (0.9.0)
     diff-lcs (1.2.5)
-    domain_name (0.5.24)
+    domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    mime-types (2.6.1)
-    mini_portile (0.6.2)
-    netrc (0.10.3)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    mime-types (2.99)
+    mini_portile2 (2.0.0)
+    netrc (0.11.0)
+    nokogiri (1.6.7.1)
+      mini_portile2 (~> 2.0.0.rc2)
     rake (10.1.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -51,6 +51,3 @@ DEPENDENCIES
   rake (~> 10.1)
   rspec (~> 3.3)
   xsd-reader!
-
-BUNDLED WITH
-   1.10.5

--- a/lib/xsd_reader/schema.rb
+++ b/lib/xsd_reader/schema.rb
@@ -19,12 +19,12 @@ module XsdReader
     end
 
     def imports
-      @imports ||= map_children("xs:import")
+      @imports ||= map_children("import")
     end
 
     def mappable_children(xml_name)
       result = super
-      result += import_mappable_children(xml_name) if xml_name != 'xs:import'
+      result += import_mappable_children(xml_name) if xml_name != 'import'
       return result.to_a
     end
 

--- a/spec/examples/ddex-mlc/avs.xsd
+++ b/spec/examples/ddex-mlc/avs.xsd
@@ -1,0 +1,11226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:avs="http://ddex.net/xml/avs/avs"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://ddex.net/xml/avs/avs"
+           elementFormDefault="unqualified"
+           attributeFormDefault="unqualified">
+   <xs:annotation>
+      <xs:documentation>© 2006-2015 Digital Data Exchange, LLC (DDEX)</xs:documentation>
+   </xs:annotation>
+   <xs:annotation>
+      <xs:documentation>This XML Schema Definition file is, together with all DDEX standards, subject to two licences: If you wish to evaluate whether the standard meets your needs please have a look at the Evaluation Licence at https://kb.ddex.net/display/HBK/Evaluation+Licence+for+DDEX+Standards. If you want to implement and use this DDEX standard, please take out an Implementation Licence. For details please go to http://ddex.net/apply-ddex-implementation-licence.</xs:documentation>
+   </xs:annotation>
+   <xs:simpleType name="AccessLimitation">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of limitation on the access of a site.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="NoLimitation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Unlimited access.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PrivateAccessOnly">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Restricted access.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="AdministratingRecordCompanyRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A role played by a Party responsible for administering Rights in a Resource or a Release.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="DesignatedDsrMessageRecipient">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An AdministratingRecordCompany that is designated to receive a sales report for Releases. Note: Typically this report is in the form of a DSR Message.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RightsAdministrator">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party administrating Rights on behalf of one or more RightsControllers.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RoyaltyAdministrator">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party that collects and distributes Royalties on behalf of one or more RightsControllers.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="AllTerritoryCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A code representing a Territory. This includes ISO 3166-1 two-letter codes, CISAC TIS codes, plus a code for Worldwide. It also includes deprecated ISO codes defined in ISO 3166-3.</xs:documentation>
+      </xs:annotation>
+      <xs:union memberTypes="avs:IsoTerritoryCode avs:TisTerritoryCode avs:DdexTerritoryCode avs:DeprecatedIsoTerritoryCode"/>
+   </xs:simpleType>
+   <xs:simpleType name="ArtistRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A role of a principal Contributor in relation to a Performance or a Fixation.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Actor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who performs spoken word or mime.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Adapter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Author of adapted Lyrics of a MusicalWork. Note: The adapted Lyrics may or may not result in a new copyright Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Architect">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Designer of a building.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Arranger">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A modifier of musical components of a Work. Note: The arranged MusicalWork may or may not result in a new copyright Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Artist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A principal Contributor to a Performance of a MusicalWork or a NonMusicalWork that results in the creation of a Resource. Note: Used for naming groups as well as individuals.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AssociatedPerformer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Artist commonly associated with a Work as one of its Performers, and whose identity is only used for accurate Work identification.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Author">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of written or spoken words which form part of a Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Band">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A group of individuals who perform vocally and/or instrumentally together.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Cartoonist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a cartoon.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Choir">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A group of Parties who perform vocally together. Typically, Choirs consist of at least 2 people in an combination of different vocal ranges.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Choreographer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a dance.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Composer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of the musical elements of a MusicalWork. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ComposerLyricist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator that plays the roles of Composer and Lyricist of a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ComputerGraphicCreator">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a computer graphics.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Conductor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who leads or conducts a Performance by a group of musicians.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Contributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party contributing to the making of a Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Dancer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who performs a dance.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Designer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a design.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Director">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who leads or supervises actors, e.g. in the prodution of a movie.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Ensemble">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A group of two or more Parties performing a MusicalWork together. Note: An Ensemble may be of any size or any grouping of Performers from a vocal duo to a full orchestra.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FeaturedArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who is not the MainArtist but is acknowledged as a significant Contributor to the Performance. Note: FeaturedArtists are often MainArtists on their own Resources. They are also frequently credited on marketing material using the term 'featuring ...'.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FilmDirector">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Director of a movie.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GraphicArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a drawing.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GraphicDesigner">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Designer of graphical elements.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Journalist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of an article for a magazine or a newspaper.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Librettist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a libretto.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Lyricist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of the Lyrics of a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MainArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who is a principal credited Artist for a Resource. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Narrator">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who tells a story or gives an account of an event.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonLyricAuthor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of written or spoken words other than Lyrics. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Orchestra">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A large group of Parties performing a MusicalWork together, predominantly using musical instruments rather than voice. An Orchestra is typically led by a Conductor.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OriginalPublisher">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party which has acquired, from a Creator, Rights in a Creation for a specified Territory and Period.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Painter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a painting.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Photographer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a photograph.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PhotographyDirector">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Director of responsible for photography.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Playwright">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a stageplay.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PrimaryMusician">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who performs a MusicalWork either vocally or instrumentally and would be considered the principal Contributor for the piece.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Producer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party responsible for an artistic input to the production of a Resource (e.g. a SoundRecording or audiovisual Recording).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Programmer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a computer program.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ScreenplayAuthor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a screenplay.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Soloist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who performs the featured Part of a MusicalWork (or a section of it) alone or with only supporting accompaniment. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="StudioMusician">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who performs a MusicalWork either vocally or instrumentally in a studio.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="StudioPersonnel">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who is employed in a studio and contributes to the making of a Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SubArranger">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of arrangements made on behalf of a SubPublisher.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Translator">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party that translates Lyrics and/or Text from one Language into another. This is also known as sub-Lyricist.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="AudioCodecType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of AudioCodec.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AAC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Advanced Audio Coding as standardized in ISO/IEC 13817-7.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ADPCM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Adaptive Differential PCM audio as defined in ITU G.721, 726 and 727.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ALaw">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An AudioCodec to optimize, i.e. modify, the dynamic range of an analogue signal for digitizing, mostly used in Europe.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AMR-NB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Adaptive Multi-Rate Narrowband.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AMR-WB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Adaptive Multi-Rate Wideband.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FLAC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Free Lossless Audio Codec developed by the Xiph.Org Foundation..</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MP2">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">MPEG Audio Layer II, as standardized in ISO/IEC 11172-3 and 13818-3.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MP3">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">MPEG Audio Layer III, as standardized in ISO/IEC 11172-3 and 13818-3.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MuLaw">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An AudioCodec to optimize, i.e. modify, the dynamic range of an analogue signal for digitizing, mostly used in North America and Japan.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PCM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pulse-code modulated audio as used e.g. on audio CDs.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PDM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pulse-Density Modulation, a form of modulation used to represent an analog signal with digital data. Direct-Stream Digital (DSD) is the trademark name used by Sony and Philips for PDM.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="QCELP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Qualcomm Code Excited Linear Prediction as developed by Qualcomm.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RealAudio">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Real Audio as developed by RealNetworks Inc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Shockwave">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Shockwave as developed by Macromedia Inc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Vorbis">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An AudioCodec developed by the Xiph.Org Foundation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WMA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Windows Media Audio as developed by Microsoft Corp.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="BinaryDataType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A format of a Fingerprint.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Binary64">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Base64-encoded binary data.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HexBinary">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hexadecimal-encoded binary data.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="BusinessContributorRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A business-related role played by a Contributor in relation to a MusicalWork.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Contributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party contributing to the making of a Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicPublisher">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party which has acquired Rights in one or more MusicalWorks for a specified Territory and Period. Note: A MusicPublisher typically administers and promotes the exploitation of the acquired Works. This term includes OriginalPublisher and SubPublisher. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OriginalPublisher">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party which has acquired, from a Creator, Rights in a Creation for a specified Territory and Period.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SubPublisher">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party which has acquired, by Agreement with a MusicPublisher, Rights in one or more MusicalWorks for a specified Territory and Period. Note: This includes Rights which are passed to subsidiaries or affiliates of a larger Organization.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SubstitutedPublisher">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party acting on behalf of a MusicPublisher or other controller of Rights in a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="CalculationType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Calculation used to determine an actual Amount paid.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string"/>
+   </xs:simpleType>
+   <xs:simpleType name="CarrierType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Carrier used for a Fixation.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="12InchDiscoSingleRemix">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Disco Single Remix 12 inches (30 cm) VinylDisk.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="33rpm10InchLP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An LP 33 rpm 10 inches (25 cm).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="33rpm10InchSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A 33 rpm 10 inches (25 cm) VinylDisk single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="33rpm12InchLP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An LP 33 rpm 12 inches (30 cm).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="33rpm12InchLp20Tracks">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An LP 33 rpm 12 inches (30 cm) with 20 tracks.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="33rpm12InchMaxiSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A 33 rpm 12 inches (30 cm) VinylDisk maxi single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="33rpm12InchSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A 33 rpm 12 inches (30 cm) VinylDisk single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="33rpm7InchLP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An LP 33 rpm 7 inches (17 cm).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="33rpm7InchSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A 33 rpm 7 inches (17 cm) VinylDisk single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="45rpm10InchLP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An LP 45 rpm 10 inches (25 cm).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="45rpm10InchMaxiSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A 45 rpm 10 inches (25 cm) VinylDisk maxi single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="45rpm10InchSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A 45 rpm 10 inches (25 cm) VinylDisk single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="45rpm12InchLP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An LP 45 rpm 12 inches (30 cm).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="45rpm12InchMaxiSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A 45 rpm 12 inches (30 cm) VinylDisk maxi single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="45rpm12InchSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A 45 rpm 12 inches (30 cm) VinylDisk single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="45rpm7InchEP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A 45 rpm 7 inches (17 cm) VinylDisk EP.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="45rpm7InchSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A 45 rpm 7 inches (17 cm) VinylDisk single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="7InchMaxiSingleRemix">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Maxi Single Remix 7 inches (17 cm) VinylDisk.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BluRay">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A blu-ray disc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CompactDisc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdCompilation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD Compilation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdEp">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD EP.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdEpEnhanced">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD EP enhanced.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdExtraCompilation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD Extra Compilation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdExtraEP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD Extra EP.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdExtraLP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD Extra LP.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdExtraMaxiRemix">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD Extra Maxi Remix.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdExtraMaxiSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD Extra Maxi Single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdExtraSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD Extra Single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdExtraSingle2Tracks">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD Extra Single 2 tracks.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdLp">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD album.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdLp5Inch">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD LP 5 inches (12 cm).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdLpEnhanced">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD album enhanced.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdLpPlusCdVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD album plus Video CD or AV CD.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdLpPlusDvdAudio">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD album plus DVD Audio.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdLpPlusDvdVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD album plus DVD Video.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdLpPlusWeb">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD album plus web link.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdMaxiSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD maxi single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdMaxiSingle3Inch">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD maxi single 3 inches.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdMaxiSingleEnhanced">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD maxi single enhanced.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdMaxiSingleRemix">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD maxi single remix.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdPlusCdBonus">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD plus a CD bonus.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdPlusDvdBonus">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD plus DVD bonus.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdRom">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD ROM.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdSingle3Inch">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD single 3 inches.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdSingle5Inch">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CD single 5 inches.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdVideo5LpNTSC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video CD 5 Album NTSC.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdVideo5LpPAL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video CD 5 Album PAL.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CdVideoAudioCompatible">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video CD audio compatible.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CombiPack">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Combi-Pack.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DCC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DCC.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DccCompilation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DCC Compilation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DualDisc">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DualDisc</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DVD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdAudio">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD Audio.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdAudio5MaxiSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD Audio 5 Maxisingle.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdAudioLP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD Audio Album.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdAudioSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD Audio 5 Single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdRom">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD-Rom.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD-Single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD Video.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdVideo5MaxiSingleNTSC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD Video 5 Maxisingle NTSC.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdVideo5MaxiSinglePAL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD Video 5 Maxisingle PAL.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdVideo5SingleNTSC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD Video 5 Single NTSC.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdVideo5SinglePAL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD Video 5 Single PAL.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdVideoLpNTSC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD Video Album NTSC.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdVideoLpPAL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD Video Album PAL.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DvdVideoLpPlusCdLpOrCdSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DVD Video Album plus CD Album or CD Single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FanPack">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Fan-Pack.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HdDvdVideoLp">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An HD DVD Video Album.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LaserDiscLp12InchNTSC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A laser disc long play 12 inches NTSC.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LpCompIdenticalToCdComp">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An LP compilation identical to a CD compilation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LpCompilation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An LP Compilation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LpIdenticalToCD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An LP identical to a CD.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An MC.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="McCompIdenticalToCdComp">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An MC Compilation identical to a CD compilation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="McCompilation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An MC Compilation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="McDoubleLP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An MC double album.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="McEP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An MC EP.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="McIdenticalToCD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An MC identical to a CD.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="McLP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An MC LP.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="McMaxiSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An MC maxisingle.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="McRemix">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An MC Remix.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="McSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An MC single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="McSingleIdenticalToCDS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An MC single identical to a CDS.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MemoryDeviceAudioLP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Memory Device Audio Album.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MemoryDeviceMixLP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Memory Device Mix Audio/Video/Other Album.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MemoryDeviceVideoLP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Memory Device Video Album.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Merchandise">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A general merchandise.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MiniDisc">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MiniDisc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MiniDiscCompilation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MiniDisc Compilation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MiniDiscEP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MiniDisc EP.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MiniDiscMaxiRemix">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MiniDisc Maxi Remix.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MiniDiscSingleMaxiSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MiniDisc Single/ Maxi Single.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PrePaidCard">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A pre-paid card.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SACD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Super Audio Compact Disc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SacdCompilation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SACD Compilation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SacdLpStereo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SACD Album Stereo.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SacdLpStereoCdAudio">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SACD Album Stereo/CD Audio.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SacdLpStereoSurround">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SACD Album Stereo/Surround.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SacdLpStereoSurroundCdAudio">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SACD Album Stereo/Surround/CD Audio.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SacdLpSurroundCdAudio">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SACD Album Surround/CD Audio.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SacdPlusDvdVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SACD plus DVD Video.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VhsNTSC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Videocassette VHS NTSC.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VhsPAL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Videocassette VHS PAL.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VhsPlusCdLp">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Videocassette VHS plus CD Album.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VhsSECAM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Videocassette VHS SECAM.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="CdProtectionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of CD protection.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="CDS100">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cactus Data Shield 100, as developed by Midbar Tech.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CDS200">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cactus Data Shield 200, as developed by Midbar Tech.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CDS300">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cactus Data Shield 300, as developed by Midbar Tech.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Key2Audio">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The key2audio copy restriction system for Audio CDs, as developed by Sony DADC.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MediaMaxCD3">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The MediaMaxCD3 copy restriction system for Audio CDs, as developed by SunnComm.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NotProtected">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CdProtectionType of a CD which is not protected.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="CharacterType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of a Character.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="MainCharacter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A central or primary Character in a storyline. This is sometimes referred to a a category A character.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OtherCharacter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Character other than a MainCharacter or a SupportingCharacter. This is sometimes referred to a a category C character.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SupportingCharacter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Character that is not focused on by the storyline. SupportingCharacters may develop a complex back-story of their own, but this is usually in relation to the MainCharacter, rather than entirely independently. This is sometimes referred to a a category B character.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="CodingType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of coding used to encode a Resource.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Lossless">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CodingType of a Resource in which no data is lost.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Lossy">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CodingType of a Resource in which data is lost.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="CollectionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Collection.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AudioChapter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A section of a SoundRecording defined by a start and end point. Typical AudioChapters are chapters of audio books.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Episode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Part of a Series made available at a specific point in time. It may be that a Season or Series is not yet complete when an Episode is made available. Episodes include 'pilots'.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FilmBundle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Bundle whose core Resources are Videos, but that may also contain Resources of different ResourceTypes. FilmBundles are typically used in electronic distribution.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MedleySegment">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Part of a Medley.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PotpourriSegment">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Part of a Potpourri.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Season">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Set of Episodes. Typically, a Season contains all Episodes to be made available in a pre-determined time frame, which often is within a twelve-month period. It may be that a Series is not yet complete when an Season is made available.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Series">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Set of Resources (Episodes) designed to be made available sequentially.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VideoChapter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A section of a Video defined by a start and end point. Typical VideoChapters are MusicalWorkVideoChapter or NonMusicalWorkVideoChapter.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="CommercialModelType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of CommercialModel (e.g. SubscriptionModel and PayAsYouGoModel). The CommercialModelType indicates how a Consumer pays for a Service or Release.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AdvertisementSupportedModel">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CommercialModel where the Service or Product offering is financed by revenue generated from the sale of advertising.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AsPerContract">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a MessageSender wishes to indicate that the value within the allowed value set is defined by the contractual relationship between MessageSender and MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DeviceFeeModel">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CommercialModel in which revenues generated from the sale of devices are shared with rights holders. The relevant content does not need to be pre-loaded onto the device for the model to apply.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FreeOfChargeModel">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CommercialModel in which a Resource, Release or Product is made available free of charge to Consumers.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PayAsYouGoModel">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CommercialModel where the Service or Product offering is financed by revenue generated from payment (set at any level but not zero) for each Usage which the Customer makes of the Service or Product.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PerformanceRoyaltiesModel">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CommercialModel in which royalties are based on performances.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RightsClaimModel">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CommercialModel in which a MessageSender is claiming ownership of rights in Release(s).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SubscriptionModel">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CommercialModel where the Service or Product offering is financed by revenue generated from a Customer Subscription.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An unknown CommercialModel. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="CompilationType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Compilation.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="InternalCompilation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Compilation where the rights in all parts are controlled by the Label providing the mandate.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonInternalCompilation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Compilation where some rights in a part are controlled by a Label not providing the mandate.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NotCompiled">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CompilationType of a Creation which is not a compilation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ContainerFormat">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of container according to its FileFormat.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AIFF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Audio Interchange File Format</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AVI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Audio Video Interleave.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MP4">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">MPEG-4 Part 14 or MP4 file format, formally ISO/IEC 14496-14:2003.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Ogg">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Multimedia container format maintained by the Xiph.Org Foundation</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="QuickTime">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">QuickTime as developed by Apple Inc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RealMedia">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Multimedia container format created by RealNetworks.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RMF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Rich Music Format, as defined by Beatnik Inc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WAV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Waveform Audio File Format</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="CreationType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Creation.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="MusicalWork">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An abstract Creation which can be expressed and fixed through sound with or without Lyrics.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Release">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An abstract entity representing a bundle of one or more Resources compiled by an issuer for the purpose of distribution to individual Consumers, directly or through intermediaries. The Resources in Releases are normally primarily SoundRecordings or music audio-visual recordings. The Release is not itself the item of trade (or Product). Products have more extensive attributes than Releases; one Release may be disseminated in many different Products.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Resource">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A digital Fixation of an expression of an abstract Work (such as a SoundRecording, a Video, an Image, Software, or a passage of Text).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="CreativeContributorRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A creative role played by a Contributor in relation to a MusicalWork.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Adapter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Author of adapted Lyrics of a MusicalWork. Note: The adapted Lyrics may or may not result in a new copyright Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Arranger">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A modifier of musical components of a Work. Note: The arranged MusicalWork may or may not result in a new copyright Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AssociatedPerformer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Artist commonly associated with a Work as one of its Performers, and whose identity is only used for accurate Work identification.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Author">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of written or spoken words which form part of a Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Composer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of the musical elements of a MusicalWork. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ComposerLyricist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator that plays the roles of Composer and Lyricist of a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Librettist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a libretto.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Lyricist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of the Lyrics of a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonLyricAuthor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of written or spoken words other than Lyrics. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SubArranger">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of arrangements made on behalf of a SubPublisher.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SubLyricist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator who substitutes or modifies the existing Lyrics of a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Translator">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party that translates Lyrics and/or Text from one Language into another. This is also known as sub-Lyricist.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="CueOrigin">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Cue according to its origin.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="LibraryMusic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork or other Creation which is made available to be used in audio-visual Releases, Resources or Collections through a music library.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PreexistingMusic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork or other Creation that has not been written specifically to be used in audio-visual Releases, Resources or Collections. This is also called InterpolatedMusic.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SpeciallyCommissionedMusic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork or other Creation written specifically for a particular audio-visual Release, Resource or Collection.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="CueSheetType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of CueSheet.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AverageCueSheet">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CueSheet that proportionally represents the music used within a given Series, Season or Episode.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CompositeCueSheet">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CueSheet that records all music used in a complete Series or within a selected number of sequential Episodes from a given Series.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="StandardCueSheet">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CueSheet in which all MusicalWorks or other Creation, with common interested parties, RightShares and UseTypes are provided separately.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SummarisedCueSheet">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CueSheet in which all MusicalWorks or other Creation, with common interested parties, RightShares and UseTypes have been combined.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SurrogateCueSheet">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CueSheet that is authorized to be used in place of the actual CueSheet.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="CueUseType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of use of a Cue.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AudioLogo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Music which is used as an audible logo within the containing Resource, Collection or Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Background">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Music which is dubbed in for effect. It is not heard by the actors or performers in an audio-visual Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Bumper">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creation used during the transition from a containing Resource, Collection or Release to a different program, including Advertisements.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="EssentialPart">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An essential Part of a Resource, e.g. a Creation that is an essential part of a scene in the containing Resource, Collection or Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FilmTheme">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Theme for a motion picture.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IndistinguishableBackground">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Music which is used as background in the containing Resource, Collection or Release and it is not or just barely audible to the audience.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OnScreenMusic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Music which is used in an on-screen Performance.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RolledUpCue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Cue in which the information about authorship and ownership is the same, but the individual constituent cue titles are not the same.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Theme">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A piece of music associated by design and often by the public, to a containing Resource, Collection or Release, often written specifically for that Resource, Collection or Release. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="CurrencyCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A code representing a Currency.</xs:documentation>
+      </xs:annotation>
+      <xs:union memberTypes="avs:IsoCurrencyCode avs:DeprecatedCurrencyCode"/>
+   </xs:simpleType>
+   <xs:simpleType name="CurrentTerritoryCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A code representing a Territory. This includes ISO 3166-1 two-letter codes, CISAC TIS codes, plus a code for Worldwide.</xs:documentation>
+      </xs:annotation>
+      <xs:union memberTypes="avs:IsoTerritoryCode avs:TisTerritoryCode avs:DdexTerritoryCode"/>
+   </xs:simpleType>
+   <xs:simpleType name="DataMismatchResponseType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of action that is a response to a DataMismatch.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AdditionalInformationOnly">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is described only in an AdditionalInformation element.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DataMismatchConfirmation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A response in which a DataMismatch is acknowledged, but the correctness of the original data is confirmed.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DataMismatchOutOfScope">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A response in which a DataMismatch is considered to be out of scope for the commercial relationship between the MessageSender and the MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DataMismatchRaisedCommercialDispute">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A response to a DataMismatch that raises a commercial dispute.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NoReaction">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A response according to which there will be no further reaction.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DataMismatchStatus">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Status of a DataMismatch.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AdditionalInformationOnly">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is described only in an AdditionalInformation element.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Corrected">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Status of a mismatch that has been corrected in such a way that message processing was continued.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Fatal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Status of a mismatch that is so severe that ingesting the original message was aborted.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NotCorrected">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Status of a mismatch that has not been corrected, and message processing was not possible to be continued.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DataMismatchType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of DataMismatch.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AdditionalInformationOnly">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is described only in an AdditionalInformation element.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ChoreographyConflict">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that occurs when a Message is received but, according to the agreed choreography, no Message was expected, or  when no Message is received but, according to the agreed choreography, a Message was expected.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ContradictoryData">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that is due to contradictory data.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DuplicatedData">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that is due to multiple copies of data.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IdentifierSyntaxMismatch">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that is due to the syntax of an Identifier not matching the expected syntax (incl. mismatch in the calculation of the check character/check sum).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MathematicalInconsistency">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that occurs when calculated information provided cannot be reconciled with individual data points (either provided or held locally).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MissingContractuallyMandatoryInformation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that occurs when a contractually mandatory field is not provided.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MissingMandatoryInformation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that occurs when a mandatory field is not provided.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MissingReferencedMusicalWorkInformation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that occurs when MusicalWork details that were referenced cannot be located.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MissingReferencedReleaseInformation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that occurs when Release details that were referenced cannot be located.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MissingReferencedResourceInformation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that occurs when Resource details that were referenced cannot be located.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MissingReferencedTechnicalResourceDetailInformation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that occurs when technical Resource details that were referenced cannot be located.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MissingResourceFile">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that occurs when a Resource file cannot be located.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TypographicMismatch">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that occurs when information received differs typographically from data locally held or previously communicated.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UnexpectedAllowedValue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that is due to an allowed value that is not part of the Set of values specified in the DdexDataDictionary.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UnexpectedMessageIntermediary">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that is due to an unexpected Party in the SentOnBehalfOf element.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UnexpectedMessageRecipient">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that is due to an unexpected MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UnexpectedMessageSender">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that is due to an unexpected MessageSender.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="XmlFormatError">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that is due to an error in the XML format.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="XmlRangeError">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DataMismatch that is due to an error in the range of the data (e.g. a negative number where only positive numbers are expected).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DdexTerritoryCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A TerritoryId which is not a TerritoryId according to the ISO 3166-1 standard or the TIS standard.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Worldwide">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Identifier which identifies all Territories in the world.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DeductionRateType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of DeductionRate.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="PennyRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RoyaltyRate in absolute monetary terms.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PercentageRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A rate of parts per hundred, resulting from the division of a Quantity by another Quantity of the same type and a multiplication of the result by 100.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DeliveryActionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of action requested for deliveries.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="ChangeDeliveryLimits">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DeliveryActionType that requests that the delivery of NewReleaseMessages should be continued, albeit with the new limits contained in the Message.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RestartDeliveryWithLimits">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DeliveryActionType that requests that the delivery of NewReleaseMessages should be resumed with the limits contained in the Message.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RestartDeliveryWithPreviousLimits">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DeliveryActionType that requests that the delivery of NewReleaseMessages should be resumed with the limits previously signalled or agreed.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="StopDelivery">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DeliveryActionType that requests that no further deliveries of NewReleaseMessages should occur until further notice.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DeliveryMessageType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of delivery Message.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="NewReleaseMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Release Notification Message Suite Standard, containing details of a new Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonDdexMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message which is not part of one of the DdexMessageSuites.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DeprecatedCurrencyCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A CurrencyCode which is not valid anymore.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="CYP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cyprus Pound (deprecated).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="EEK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kroon (deprecated).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MTL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Maltese Lira (deprecated).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ROL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Old Leu (deprecated).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SIT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tolar (deprecated).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SKK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Slovak Koruna (deprecated).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DeprecatedIsoTerritoryCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">An ISO 3166-3 four-letter code representing a Territory, which is a replacement for a deprecated ISO 3166-1 code.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AIDJ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">French Afar and Issas, Name changed to Djibouti (DJ), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ANHH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Netherlands Antilles, Divided into: Bonaire, Sint Eustatius and Saba (BQ), Curaçao (CW), Sint Maarten (Dutch part) (SX), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BQAQ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">British Antarctic Territory, Merged into Antarctica (AQ), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BUMM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Burma, Name changed to Myanmar (MM), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BYAA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Byelorussian SSR, Name changed to Belarus (BY), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CSHH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Czechoslovakia, Divided into: Czech Republic (CZ), Slovakia (SK), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CSXX">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Serbia and Montenegro, Divided into: Montenegro (ME), Serbia (RS), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CTKI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Canton and Enderbury Islands, Merged into Kiribati (KI), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DDDE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">German Democratic Republic, Merged into Germany (DE), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DYBJ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Dahomey, Name changed to Benin (BJ), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FQHH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">French Southern and Antarctic Territories, Divided into: Part of Antarctica (AQ) (i.e., Adálie Land), French Southern Territories (TF), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FXFR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">France, Metropolitan, Merged into France (FR), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FX">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">France, Metropolitan, Merged into France (FR), (exceptionally reserved ISO 3166-1 code).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GEHH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Gilbert and Ellice Islands, Divided into: Kiribati (KI), Tuvalu (TV), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HVBF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Upper Volta, Name changed to Burkina Faso (BF), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="JTUM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Johnston Island, Merged into United States Minor Outlying Islands (UM), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MIUM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Midway Islands, Merged into United States Minor Outlying Islands (UM), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NHVU">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">New Hebrides, Name changed to Vanuatu (VU), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NQAQ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Dronning Maud Land, Merged into Antarctica (AQ), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NTHH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Neutral Zone, Divided into: Part of Iraq (IQ), Part of Saudi Arabia (SA), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PCHH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pacific Islands, Trust Territory of the, Divided into: Marshall Islands (MH), Micronesia, Federated States of (FM), Northern Mariana Islands (MP), Palau (PW), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PUUM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">U.S. Miscellaneous Pacific Islands, Merged into United States Minor Outlying Islands (UM), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PZPA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Panama Canal Zone, Merged into Panama (PA), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RHZW">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Southern Rhodesia, Name changed to Zimbabwe (ZW), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SKIN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sikkim, Merged into India (IN), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SUHH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">USSR, Divided into: Armenia (AM), Azerbaijan (AZ), Estonia (EE), Georgia (GE), Kazakhstan (KZ), Kyrgyzstan (KG), Latvia (LV), Lithuania (LT), Moldova, Republic of (MD), Russian Federation (RU), Tajikistan (TJ), Turkmenistan (TM), Uzbekistan (UZ), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TPTL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">East Timor, Name changed to Timor-Leste (TL), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VDVN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Viet-Nam, Democratic Republic of, Merged into Viet Nam (VN), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WKUM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Wake Island, Merged into United States Minor Outlying Islands (UM), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="YDYE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Yemen, Democratic, Merged into Yemen (YE), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="YUCS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Yugoslavia, Name changed to Serbia and Montenegro (CS), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ZRCD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Zaire, Name changed to Congo, the Democratic Republic of the (CD), (Source ISO 3166-3).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DigitizationMode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Digitization mode of a Resource.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AAD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Digitization in which a Resource is created by analogue recording, analogue mixing and digital mastering.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ADD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Digitization in which a Resource is created by analogue recording, digital mixing and digital mastering.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DDD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Digitization in which a Resource is created by digital recording, digital mixing and digital mastering.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DisputeReason">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of reason for a Dispute.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="MissingInformation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Dispute whose reason is that not enough information was provided to make a decision (e.g. when sent from a RelinquishingPublisher to an AcquiringPublisher).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NotPartOfCatalogTransfer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Dispute whose reason is that a Work/Share was not part of the agreed CatalogTtransfer (typically sent from a RelinquishingPublisher to an AcquiringPublisher).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MoreResearchNeeded">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Dispute whose reason is that more research is necessary to conform whether a Work/Share is part of the agreed CatalogTtransfer (typically sent from a RelinquishingPublisher to an AcquiringPublisher).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DistributionChannelType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of DistributionChannel used to disseminate a Service or Release to a Consumer.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AsPerContract">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a MessageSender wishes to indicate that the value within the allowed value set is defined by the contractual relationship between MessageSender and MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Broadcast">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Deliver a Resource using radio waves on the radio frequency portion of the electromagnetic spectrum. This is deprecated as an allowed value for UseType. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Cable">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DistributionChannel in which Releases are transmitted via a cable network as used by, e.g., Cable TV providers.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Internet">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DistributionChannel in which Releases are transmitted  via the Internet.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="InternetAndMobile">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DistributionChannel in which Releases are transmitted via either Internet or MobileTelephone. This is often referred to as dual delivery.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IPTV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DistributionChannel in which Releases are transmitted via Internet Protocol Television networks.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MobileTelephone">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A wireless DistributionChannel in which Releases are transmitted via mobile telephony networks, including 1G, 2G, 2.5G and 3G networks.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Narrowcast">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Deliver a Resource to a specific list of recipients, by terrestrial or satellite transmission. This is deprecated as an allowed value for UseType. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OnDemandStream">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Stream a Release with full interactivity.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PeerToPeer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DistributionChannel in which Releases are transmitted via computer networks that rely primarily on the computing power and bandwidth of the participants in the network rather than concentrating on a relatively low number of servers.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Physical">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Distribution of Releases via physical Carriers, such as CDs. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Satellite">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">DistributionChannel in which Releases are transmitted via Satellites.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Simulcast">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Stream simultaneously over two or more different media systems or channels. This is deprecated as an allowed value for UseType. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Webcast">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Deliver a Resource over the Internet using streaming technology. This is deprecated as an allowed value for UseType. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DpidStatus">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Status of a DdexPartyId.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Active">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Status of a DdexPartyId which is active.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Deleted">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Status of a DdexPartyId which has been deleted.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Replaced">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Status of a DdexPartyId which has been replaced.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DrmEnforcementType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of DRM enforcement.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="DrmEnforced">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DrmEnforcementType of a Creation which is protected by DRM.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NotDrmEnforced">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DrmEnforcementType of a Creation which is not protected by DRM.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DrmPlatformType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of DrmPlatform.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="3Day">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">3-Day or 3-Play DRM system developed by Microsoft for its Zune.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Fairplay">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DRM system developed by Apple Inc for its iTunes Music Store.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OMA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DRM system standardized by the Open Mobile Alliance.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WindowsMediaDRM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DRM system developed by Microsoft Corp.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="DsrMessageType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Message in the Sales Reporting Message Suite Standard.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="SalesReportToRecordCompanyMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A sales reporting Message in the Sales Reporting Message Suite Standard, sent to a record company.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SalesReportToSocietyMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A sales reporting Message in the Sales Reporting Message Suite Standard, sent to a MusicalWork Licensor.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="EquipmentType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Equipment.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Computer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Machine for digital processing.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Microphone">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A input device for recording sound.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Recorder">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A device for recording signals.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SignalProcessor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A device for processing signals.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Software">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A program that enables a Computer to perform a specific task(s).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Loudspeaker">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A device for emitting sound.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ErnMessageType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Message in the Release Notification Message Suite Standard.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="NewReleaseMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Release Notification Message Suite Standard, containing details of a new Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ErncFileStatus">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Status of a File in terms of its validity in the Release Delivery Choreography Standard.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="ArtistRoleUnknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which an ArtistRole is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CommercialReleaseDateInvalid">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which a commercial Release Date is not valid.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ConflictingAvailabilityPeriods">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which multiple availability Periods are given that start on the same date for the same country for the same usage.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DuplicatedPublisherNames">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which duplicate publisher names are given.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ErnMissing">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which an ERN File is missing.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FileOK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which a File contains no errors.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IdentifierInvalid">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which an Identifier is not valid, e.g. because the same ISRC is given for two different tracks.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IdentifierSyntaxInvalid">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which an Identifier syntax is not valid.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="InternalError">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which there is an internal error at the MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MetadataMissing">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which metadata fileds required according to the Profile in use are missing.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NewReleaseMessageInvalid">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which an NewReleaseMessage doesn't validate.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NoDealForTrackRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which there is no Deal for any Track Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NoDealInNewReleaseMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which there is no Deal section in the NewReleaseMessage.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OriginalReleaseDateLaterThanReleaseDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which the OriginalReleaseDate is later than the ReleaseDate.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PrimaryArtistNameMissing">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which a Name of the primary Artist is missing.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ResourceCorrupt">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which a Resource is corrupt.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ResourceMissing">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which a Resource is missing from a context in which it was expected to be found.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ResourceNotMeetingSpecifications">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which a Resource is valid, but does not meet required minimum specifications.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SignatureOrHashSumWrongOrMissing">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which a Signature or a HashSum is incorrect or missing.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UnsupportedUsage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which a usage (e.g. a CommercialModelType or a UseType for the commercial relationship between the MessageSender and the MessageRecipient) is invalid.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ErncProposedActionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of action that is proposed.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="ResendXmlOnly">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A request to resend the acknowledged Message, but not any referenced Files.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ResendXmlAndResources">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A request to resend the acknowledged Message including all Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ExpressionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of expression indicating how it should be perceived.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Informative">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An ExpressionType according to which the expression is informative.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Instructive">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An ExpressionType according to which the expression is instructive.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ExternallyLinkedResourceType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Resource pointed to by an ExternalLink.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AdditionalMetadata">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Resource which provides to the MessageRecipient additional data not provided in the DdexMessage.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Logo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Image representing a Brand or Organization.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PromotionalImage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Image used for marketing a Release, Resource or associated Party.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PromotionalInformation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Resource other than an Image or item used for marketing a Release, Resource or associated Party.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PromotionalItem">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Resource other than an Image or information used for marketing a Release, Resource or associated Party.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="FileStatus">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Status of a File in terms of its validity.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="FileMissing">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which a File is missing from a context in which it was expected to be found.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FileOK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which a File contains no errors.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HashSumWrong">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which a HashSum is incorrect.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SignatureWrong">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which a Signature is incorrect.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="FingerprintAlgorithmType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Fingerprint algorithm.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="GoverningAgreementType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of governing agreement.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="HashSumAlgorithmType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of HashSumAlgorithm.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="MD4">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The MD4 HashSumAlgorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MD5">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The MD5 HashSumAlgorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SHA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The SHA HashSumAlgorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SHA1">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The SHA1 HashSumAlgorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ImageCodecType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of ImageCodec.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="GIF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Grafics Interchange Format as specified by W3C.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="JPEG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An ImageCodec defined by the Joint Photographic Expert Group and specified in ISO/IEC 10918.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="JPEG2000">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An ImageCodec defined by the Joint Photographic Expert Group and specified in ISO/IEC 15444.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PNG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Portable Network Graphics, a bitmapped image format that employs lossless data compression, as specified in ISO/IEC 15948:2003.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TIFF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tagged Image File Format as specified by Adobe.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ImageType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Image.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="BackCoverImage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Image on the back cover of a Carrier.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BookletBackImage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Image on the back of a small book usually in reference to the packaging relating to a physical Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BookletFrontImage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Image on the front of a small book usually in reference to the packaging relating to a physical Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DocumentImage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Image of written Text.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FrontCoverImage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Image on the front cover of a Carrier.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Icon">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Image used in a graphical user interface (e.g., of a computer or mobile phone) to represent a program, hyperlink, Creation or command.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Logo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Image representing a Brand or Organization.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Photograph">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A still Image recorded by a camera.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Poster">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A large-scale Image usually intended for display in a public place.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TrayImage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Image located behind the CD when packaged in a jewel case.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VideoScreenCapture">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A still Image captured from a Video.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Wallpaper">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Image intended as background on a portable device such as a mobile phone or computer.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="InvoiceAvailabilityStatus">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Status of the availability of an invoice.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="InvoiceAvailable">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An InvoiceAvailabilityStatus indicating that an invoice is currently available.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="InvoiceNotAvailable">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An InvoiceAvailabilityStatus indicating that no invoice is currently available.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="IsoCurrencyCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">An ISO4217 three-letter code representing a Currency.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AED">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">UAE Dirham.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AFN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Afghani.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ALL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lek.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AMD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Armenian Dram.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ANG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Netherlands Antillian Guilder.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AOA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kwanza.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ARS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Argentine Peso.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AUD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Australian Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AWG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Aruban Guilder.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AZN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Azerbaijanian Manat.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BAM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Convertible Marks.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BBD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Barbados Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BDT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Taka.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BGN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bulgarian Lev.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BHD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bahraini Dinar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BIF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Burundi Franc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BMD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bermudian Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BND">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Brunei Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BOB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Boliviano.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BOV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mvdol.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BRL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Brazilian Real.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BSD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bahamian Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BTN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ngultrum.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BWP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pula.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BYR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Belarussian Ruble.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BZD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Belize Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CAD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Canadian Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CDF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Congolese Franc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CHF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Swiss Franc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CLF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Unidades de fomento.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CLP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Chilean Peso.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CNY">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Yuan Renminbi.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="COP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Colombian Peso.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="COU">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Unidad de Valor Real.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CRC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Costa Rican Colón.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CUC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Peso Convertible.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CUP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cuban Peso.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CVE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cape Verde Escudo.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CZK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Czech Koruna.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DJF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Djibouti Franc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DKK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Danish Krone.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DOP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Dominican Peso.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DZD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Algerian Dinar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="EGP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Egyptian Pound.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ERN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nakfa.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ETB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ethiopian Birr.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="EUR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Euro.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FJD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Fiji Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FKP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Falkland Islands Pound.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GBP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pound Sterling.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GEL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lari.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GHS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cedi.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GIP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Gibraltar Pound.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GMD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Dalasi.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GNF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guinea Franc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GTQ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Quetzal.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GYD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guyana Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HKD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hong Kong Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HNL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lempira.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HRK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Croatian Kuna.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HTG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Gourde.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HUF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Forint.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IDR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Rupiah.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ILS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">New Israeli Sheqel.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="INR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Indian Rupee.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IQD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Iraqi Dinar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IRR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Iranian Rial.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ISK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Iceland Króna.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="JMD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Jamaican Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="JOD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Jordanian Dinar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="JPY">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Yen.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KES">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kenyan Shilling.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KGS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Som.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KHR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Riel.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KMF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Comoro Franc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KPW">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">North Korean Won.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KRW">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Won.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KWD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kuwaiti Dinar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KYD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cayman Islands Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KZT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tenge.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LAK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kip.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LBP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lebanese Pound.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LKR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sri Lanka Rupee.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LRD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Liberian Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LSL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Loti.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LTL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lithuanian Litas.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LVL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Latvian Lats.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LYD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Libyan Dinar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MAD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Moroccan Dirham.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MDL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Moldovan Leu.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MGA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Malagasy Ariary.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MKD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Denar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MMK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kyat.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MNT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tugrik.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MOP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pataca.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MRO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ouguiya.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MUR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mauritius Rupee.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MVR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Rufiyaa.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MWK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kwacha.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MXN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mexican Peso.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MXV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mexican Unidad de Inversion.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MYR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Malaysian Ringgit.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MZM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Metical.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NAD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Namibia Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NGN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Naira.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NIO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Córdoba Oro.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NOK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Norwegian Krone.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NPR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nepalese Rupee.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NZD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">New Zealand Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OMR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Rial Omani.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PAB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Balboa.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PEN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nuevo Sol.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PGK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kina.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PHP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Philippine Peso.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PKR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pakistan Rupee.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PLN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Zloty.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PYG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guarani.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="QAR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Qatari Rial.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RON">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">New Leu.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RSD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Serbian Dinar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RUB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Russian Ruble.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RWF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Rwanda Franc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SAR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saudi Riyal.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SBD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Solomon Islands Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SCR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Seychelles Rupee.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SDG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sudanese Pound.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SEK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Swedish Krona.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SGD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Singapore Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SHP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saint Helena Pound.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SLL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Leone.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SOS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Somali Shilling.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SRD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Suriname Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="STD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Dobra.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SVC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">El Salvador Colón.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SYP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Syrian Pound.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SZL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lilangeni.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="THB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Baht.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TJS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Somoni.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TMT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Manat.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TND">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tunisian Dinar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TOP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pa'anga.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TRY">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Turkish Lira.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TTD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Trinidad and Tobago Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TWD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">New Taiwan Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TZS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tanzanian Shilling.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UAH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hryvnia.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UGX">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Uganda Shilling.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="USD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">US Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UYI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Uruguay Peso en Unidades Indexadas.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UYU">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Peso Uruguayo.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UZS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Uzbekistan Sum.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VEF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bolivar Fuerte.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VND">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Dong.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VUV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Vatu.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WST">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tala.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="XAF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">CFA Franc BEAC.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="XCD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">East Caribbean Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="XOF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">CFA Franc BCEAO.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="XPF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">CFP Franc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="YER">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Yemeni Rial.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ZAR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Rand.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ZMK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Zambian Kwacha.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ZWL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Zimbabwe Dollar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="IsoLanguageCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">An ISO639-1 two-letter code representing a Language.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="aa">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Afar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ab">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Abkhazian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ae">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Avestan.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="af">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Afrikaans.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ak">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Akan.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="am">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Amharic.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="an">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Aragonese.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ar">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Arabic.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="as">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Assamese.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="av">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Avaric.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ay">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Aymara.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="az">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Azerbaijani.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ba">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bashkir.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="be">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Belarusian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="bg">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bulgarian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="bh">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bihari.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="bi">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bislama.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="bm">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bambara.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="bn">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bengali.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="bo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tibetan.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="br">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Breton.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="bs">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bosnian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ca">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Catalan or Valencian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ce">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Chechen.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ch">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Chamorro.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="co">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Corsican.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="cr">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cree.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="cs">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Czech.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="cu">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Church Slavic or Old Slavonic or Church Slavonic or Old Bulgarian or Old Church Slavonic.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="cv">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Chuvash.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="cy">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Welsh.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="da">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Danish.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="de">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">German.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="dv">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Divehi or Dhivehi or Maldavian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="dz">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Dzongkha.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ee">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ewe.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="el">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Modern Greek (1453-).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="en">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">English.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="eo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Esperanto.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="es">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Spanish or Castilian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="et">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Estonian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="eu">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Basque.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="fa">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Persian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ff">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Fulah.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="fi">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Finnish.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="fj">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Fijian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="fo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Faroese.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="fr">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">French.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="fy">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Western Frisian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ga">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Irish.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="gd">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Gaelic or Scottish Gaelic.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="gl">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Galician.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="gn">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guarani.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="gu">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Gujarati.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="gv">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Manx.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ha">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hausa.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="he">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hebrew.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="hi">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hindi.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ho">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hiri Motu.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="hr">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Croatian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ht">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Haitian or Haitian Creole.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="hu">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hungarian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="hy">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Armenian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="hz">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Herero.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ia">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Interlingua (International Auxiliary Language Association).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="id">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Indonesian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ie">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Interlingue or Occidental.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ig">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Igbo.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ii">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sichuan Yi or Nuosu.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ik">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Inupiaq.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="io">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ido.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="is">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Icelandic.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="it">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Italian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="iu">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Inuktitut.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ja">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Japanese.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="jv">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Javanese.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ka">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Georgian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="kg">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kongo.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ki">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kikuyu or Gikuyu.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="kj">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kuanyama or Kwanyama.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="kk">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kazakh.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="kl">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kalaallisut or Greenlandic.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="km">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Central Khmer.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="kn">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kannada.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ko">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Korean.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="kr">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kanuri.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ks">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kashmiri.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ku">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kurdish.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="kv">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Komi.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="kw">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cornish.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ky">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kirghiz or Kyrgyz.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="la">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Latin.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="lb">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Luxembourgish or Letzeburgesch.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="lg">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ganda.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="li">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Limburgan or Limburger or Limburgish.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ln">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lingala.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="lo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lao.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="lt">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lithuanian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="lu">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Luba-Katanga.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="lv">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Latvian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="mg">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Malagasy.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="mh">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Marshallese.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="mi">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Maori.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="mk">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Macedonian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ml">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Malayalam.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="mn">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mongolian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="mo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Moldavian. This code has been withdrawn, recommending the code 'ro' also for Moldavian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="mr">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Marathi.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ms">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Malay.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="mt">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Maltese.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="my">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Burmese.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="na">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nauru.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="nb">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Norwegian Bokmål</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="nd">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">North Ndebele.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ne">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nepali.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ng">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ndonga.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="nl">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Dutch or Flemish.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="nn">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Norwegian Nynorsk.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="no">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Norwegian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="nr">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">South Ndebele.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="nv">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Navajo or Navaho.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ny">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Chichewa or Chewa or Nyanja.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="oc">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Occitan (post 1500).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="oj">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ojibwa.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="om">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Oromo.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="or">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Oriya.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="os">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ossetian or Ossetic.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="pa">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Panjabi or Punjabi.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="pi">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pali.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="pl">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Polish.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ps">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pushto or Pashto.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="pt">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Portuguese.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="qu">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Quechua.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="rm">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Romansh.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="rn">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Rundi.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ro">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Romanian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ru">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Russian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="rw">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kinyarwanda.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="sa">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sanskrit.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="sc">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sardinian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="sd">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sindhi.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="se">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Northern Sami.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="sg">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sango.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="si">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sinhala or Sinhalese.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="sk">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Slovak.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="sl">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Slovenian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="sm">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Samoan.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="sn">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Shona.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="so">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Somali.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="sq">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Albanian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="sr">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Serbian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ss">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Swati.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="st">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Southern Sotho.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="su">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sundanese.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="sv">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Swedish.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="sw">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Swahili.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ta">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tamil.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="te">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Telugu.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="tg">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tajik.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="th">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Thai.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ti">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tigrinya.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="tk">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Turkmen.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="tl">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tagalog.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="tn">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tswana.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="to">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tonga (Tonga Islands).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="tr">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Turkish.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ts">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tsonga.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="tt">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tatar.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="tw">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Twi.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ty">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tahitian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ug">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Uighur.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="uk">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ukrainian.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ur">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Urdu.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="uz">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Uzbek.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ve">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Venda.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="vi">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Vietnamese.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="vo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Volapük.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="wa">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Walloon.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="wo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Wolof.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="xh">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Xhosa.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="yi">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Yiddish.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="yo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Yoruba.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="za">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Zhuang or Chuang.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="zh">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Chinese.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="zu">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Zulu.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="IsoTerritoryCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">An ISO 3166-1 two-letter code representing a Territory.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Andorra (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The United Arab Emirates (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Afghanistan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Antigua and Barbuda (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Anguilla (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Albania (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Armenia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Netherlands Antilles (Source:ISO 3166-1). This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Angola (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AQ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Antarctica (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Argentina (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">American Samoa (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Austria (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AU">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Australia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AW">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Aruba (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AX">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Åland Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AZ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Azerbaijan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bosnia and Herzegovina (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Barbados (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bangladesh (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Belgium (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Burkina Faso (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bulgaria (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bahrain (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Burundi (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BJ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Benin (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saint Barthélemy (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bermuda (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Brunei (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bolivia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BQ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bonaire, Sint Eustatius and Saba (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Brazil (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Bahamas (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bhutan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bouvet Island (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BW">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Botswana (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BY">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Belarus (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BZ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Belize (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Canada (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cocos Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Democratic Republic of the Congo (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Central African Republic (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Congo (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Switzerland (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Côte d'Ivoire (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cook Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Chile (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cameroon (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">China (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Colombia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Costa Rica (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Czechslovakia (until 1993) or Serbia and Montenegro (2003-2006) (Source:ISO 3166-1). This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CU">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cuba (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cape Verde (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CW">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Curaçao (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CX">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Christmas Island (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CY">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cyprus (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CZ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Czech Republic (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Germany (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DJ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Djibouti (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Denmark (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Dominica (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Dominican Republic (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DZ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Algeria (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="EC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ecuador (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="EE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Estonia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="EG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Egypt (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="EH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Western Sahara (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ER">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Eritrea (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ES">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Spain (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ET">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ethiopia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Finland (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FJ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Fiji (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Falkland Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Micronesia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Faroe Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">France (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Gabon (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The United Kingdom (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Grenada (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Georgia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">French Guiana (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guernsey (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ghana (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Gibraltar (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Greenland (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Gambia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guinea (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guadeloupe (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GQ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Equatorial Guinea (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Greece (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">South Georgia and The South Sandwich Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guatemala (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GU">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guam (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GW">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guinea-Bissau (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GY">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guyana (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hong Kong (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Heard Island and McDonald Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Honduras (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Croatia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Haiti (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HU">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hungary (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ID">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Indonesia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ireland (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Israel (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Isle of Man (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">India (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The British Indian Ocean Territory (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IQ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Iraq (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Iran (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Iceland (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Italy (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="JE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Jersey (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="JM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Jamaica (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="JO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Jordan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="JP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Japan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kenya (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kyrgyzstan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cambodia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kiribati (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Comoros (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saint Kitts and Nevis (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Democratic People's Republic of Korea (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Republic of Korea (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KW">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kuwait (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KY">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cayman Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KZ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kazakhstan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Laos (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lebanon (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saint Lucia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Liechtenstein (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sri Lanka (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Liberia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lesotho (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lithuania (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LU">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Luxembourg (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Latvia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LY">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Libya (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Morocco (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Monaco (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Moldova (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ME">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Montenegro (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saint Martin (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Madagascar (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Marshall Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Macedonia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ML">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mali (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Myanmar (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mongolia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Macao (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Northern Mariana Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MQ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Martinique (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mauritania (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Montserrat (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Malta (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MU">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mauritius (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Maldives (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MW">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Malawi (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MX">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mexico (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MY">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Malaysia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MZ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mozambique (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Namibia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">New Caledonia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Niger (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Norfolk Island (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nigeria (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nicaragua (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Netherlands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Norway (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nepal (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nauru (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NU">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Niue (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NZ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">New Zealand (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Oman (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Panama (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Peru (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">French Polynesia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Papua New Guinea (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Philippines (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pakistan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Poland (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saint Pierre and Miquelon (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pitcairn (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Puerto Rico (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Occupied Palestinian Territory (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Portugal (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PW">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Palau (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PY">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Paraguay (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="QA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Qatar (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Réunion (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Romania (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Serbia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RU">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Russia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RW">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Rwanda (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saudi Arabia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Solomon Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Seychelles (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Sudan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sweden (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Singapore (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saint Helena (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Slovenia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SJ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Svalbard and Jan Mayen (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Slovakia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sierra Leone (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">San Marino (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Senegal (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Somalia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Suriname (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">South Soudan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ST">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sao Tome and Principe (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">El Salvador (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SX">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sint Maarten (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SY">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Syria (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SZ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Swaziland (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Turks and Caicos Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TD">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Chad (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The French Southern Territories (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Togo (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TH">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Thailand (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TJ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tajikistan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tokelau (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TL">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Timor-Leste (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Turkmenistan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tunisia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tonga (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Turkey (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Trinidad and Tobago (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tuvalu (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TW">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Taiwan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TZ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tanzania (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ukraine (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Uganda (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">United States Minor Outlying Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="US">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The United States (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UY">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Uruguay (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UZ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Uzbekistan (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Holy See (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saint Vincent and The Grenadines (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Venezuela (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VG">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">British Virgin Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">US Virgin Islands (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Viet Nam (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VU">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Vanuatu (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Wallis and Futuna (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Samoa (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="YE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Yemen (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="YT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mayotte (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ZA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">South Africa (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ZM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Zambia (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ZW">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Zimbabwe (Source:ISO 3166-1).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="LabelNameType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of LabelName.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="DisplayLabelName">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Name of a Label provided for search, discovery and display purposes.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="LicenseOrClaimRefusalReason">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of reason for a refusing a License or Claim.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AgreementOfAdditionalProvisionsRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Additional provisions needs to be agreed before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfAdvancePaymentRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about advance payments needs to be corrected before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfGuaranteeRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about guarantees need to be corrected before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfLicenseeRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about whether a License is required needs to be corrected before a license might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfMostFavoredNationClauseRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about a most-favored nation clause needs to be corrected before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfNumberOfResourcesRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about the number of Resources needs to be corrected before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfPlayingTimeRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about playing time (Duration) needs to be corrected before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfPublisherInformationRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about the Publisher(s) of a Work needs to be corrected before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfPublisherPercentageRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about RightSharePercentages needs to be corrected before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfRateRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about rates need to be corrected before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfReleaseCreatorInformationRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about the Creator(s) of a Release needs to be corrected before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfReleaseDateRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about the ReleaseDates of the Release need to be corrected before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfReleaseTitleRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about the Title(s) of a Release needs to be corrected before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfWorkContributorRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about the Creator(s) of a Work needs to be corrected before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectionOfWorkTitleRequired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about the Title(s) of  a Work needs to be corrected before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DealExpired">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Deal under which a License was requested or granted has expired.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DifferentWork">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A different Work than the one for which a License or Claim was requested or granted/provided is being used.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DirectLicense">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Publisher Licenses, or makes Claims for, the Work directly.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DuplicateLicense">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A License has already been issued for the Work and its exploitation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DuplicateRequest">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Request for a License or Claim is a duplicate.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ImportLicenseExists">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Less than 600 units of this Product have been imported to Canada under a license issued elsewhere.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IncorrectClaim">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Claim information on one or more Works is thought to be incorrect.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IncorrectControlledCompositionRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A 'Controlled Composition' rates has not been applied, or has been applied incorrectly.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="InHouseLicenseExists">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">This Product has already been fully covered by License(s) acquired directly from an affiliated Party.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="InsufficientInformation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Insufficient information has been made to grant a License or to make a Claim.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LicenseeNotAuthorized">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Licensee indicates that it is not authorized to provide a License for the Work.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MedleyRequest">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information about the individual Works that make up the medley needs to be provided before a License might be issued or a Claim be made.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NoOptIn">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Publisher did not agree to make its Works available for these types of deals.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NoPublisherClaim">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Publisher indicated in the LicenseOrClaimRequest does not claim the Work.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OwnershipUnconfirmed">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Information on the License is thought to be incorrect or incomplete (for example, price or Identifier details).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ProductUnavailable">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Product is not available or is no longer available, and no royalties remain for distribution.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PublisherNotRepresented">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Publisher is not represented by the Licensee.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReleaseWithdrawn">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Licensee indicates that a Release has been withdrawn.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RelinquishedClaim">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Publisher has relinquished the Claim on the relevant Work.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WorkDeletedFromRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Work was deleted from the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WorkIncorrectlyIdentified">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">One or more of the Works named in the LicenseRequest is thought to have been wrongly identified. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WorkInPublicDomain">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Work is in the public domain in a requested Territory.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WorkNotUsed">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Licensee indicates that the Work has not been used.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WorkUnknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Licensee indicates that the Work is not known.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="LicenseOrClaimRequestUpdateReason">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of reason for updating a License request.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AdditionalInformationProvided">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A LicenseOrClaimRequestUpdateReason indicating that AdditionalInformation is provided.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AdditionalInformationProvidedAsRequested">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A LicenseOrClaimRequestUpdateReason indicating that AdditionalInformation is provided as requested.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="LicenseOrClaimUpdateReason">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of reason for updating a License.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="NewLicenseIssued">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A LicenseOrClaimUpdateReason indicating that a new License has been issued for an existing RightShare.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NewRightShareIdentified">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A LicenseOrClaimUpdateReason indicating that a new RightShare has been identified.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NewRightsholderIdentified">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A LicenseOrClaimUpdateReason indicating that a new rightsholder has been identified.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NewWorkIdentified">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A LicenseOrClaimUpdateReason indicating that a new Work has been identified.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Revoked">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A LicenseStatus of a License which has been revoked.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="LicenseRejectionReason">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of reason for a rejecting a License.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="DisagreementOverRoyalties">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A disagreement over Royalties or RoyaltyRate.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DisagreementOverScopeOfLicense">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A disagreement over the scope of the License (e.g. the use types granted).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LicenseExists">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A License is already in place.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LicenseNotNeeded">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A License is not needed any more.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WrongAddressee">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The MessageSender is not the right Party to send the License to.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WorkInPublicDomain">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Work is in the public domain in a requested Territory.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="LicenseStatus">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A legal Status of a License for a Claim.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Active">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A LicenseStatus of a License which is active.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Pending">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A LicenseStatus of a License which is pending.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Revoked">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A LicenseStatus of a License which has been revoked.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="LicensingProcessStatus">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">An operational Status of a licensing process.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Pending">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A LicenseStatus of a License which is pending.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Processed">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A LicensingProcessStatus of a process that has been processed.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ThirdPartyInformationRequested">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A LicensingProcessStatus in which information has been requested from a third Party.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="LodFileStatus">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Status of a File in terms of its validity in the Release Delivery Choreography Standard.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="FileOK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A State in which a File contains no errors.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="LodProposedActionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of action that is proposed.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="ResendXmlOnly">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A request to resend the acknowledged Message, but not any referenced Files.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="MembershipType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of membership.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="NationalMember">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party which has assigned relevant rights to a claiming society for the Territory of the claiming society.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RegionalMember">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party which has assigned relevant rights to a claiming society for several Territories.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WorldwideMember">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party which has assigned relevant rights to a claiming society for the world.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="MessageActionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of action requested in a Message.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="BackCatalogDelivery">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MessageActionType that contains a delivery of one or more NewReleaseMessage(s) of back catalog Releases.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HighPriorityDelivery">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MessageActionType that contains a delivery of one or more NewReleaseMessage(s) that should be processed with high priority.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NewReleaseDelivery">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MessageActionType that contains a delivery of one or more NewReleaseMessage(s) containing new Releases.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReDelivery">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MessageActionType that contains one or more NewReleaseMessage(s) providing re-deliveries of Releases.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TakeDown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MessageActionType that contains a delivery of a take-down notice for a Release. This Message should be processed with high priority.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="MessageContentRevenueType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of revenue to which the content of the Message relates.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="NonTransactionalRevenue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Revenue accruing from sources other than SalesTransactions. Example: Revenue that is not directly related to ReleaseTransactions such as Revenues for set-up fees, Revenues future earnings, advances, money guarantees, other accrued pre-payments, unused subscription fees.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TransactionalRevenue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Revenue accruing directly from ReleaseTransactions.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="MessageContextType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Message in the Letters Of Direction Choreography Standard.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="MusicalWorkClaimRequestMessageInIdentificationCycle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Musical Work Claim Request Message in the Identification Cycle.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkClaimNotificationMessageInIdentificationCycle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Musical Work Claim Notification Message in the Identification Cycle.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkClaimRequestMessageInConfirmationCycle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Musical Work Claim Request Message in the Confirmation Cycle.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkClaimNotificationMessageInConfirmationCycle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Musical Work Claim Notification Message in the Confirmation Cycle.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkClaimNotificationMessageInLoCCycleAsLoDMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Musical Work Claim Notification Message in the LoC Cycle as the LoD message.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkClaimNotificationMessageInLoCCycleAsLoDConfirmation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Musical Work Claim Notification Message in the LoC Cycle as the LoD confirmation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="MessageControlType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Message according to its operational status.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="LiveMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message containing data which is expected to be used for commercial purposes.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TestMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message containing data which is expected to be used for testing purposes.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="MidiType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of MIDI.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="MonophonicMidi">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MIDI using one voice.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PolyphonicMidi">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MIDI using two or more voices.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="MlcMessageType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Message in the Music Licensing Company Message Suite.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="DeclarationOfSoundRecordingRightsClaimMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Music Licensing Company Message Suite Standard containing details of a SoundRecording. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RequestSoundRecordingInformationMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Music Licensing Company Message Suite Standard containing a request for a declaration of SoundRecordings. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RevokeSoundRecordingRightsClaimMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Music Licensing Company Message Suite Standard in which a claim, typically communicated via a DeclarationOfSoundRecordingRightsClaimMessage, is revoked. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SalesReportMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Music Licensing Company Message Suite Standard used by one Music Licensing Company to inform a second Music Licensing Company about unit sales of Releases in electronic or physical formats.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DeclarationOfRevenueMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Music Licensing Company Message Suite Standard containing a declaration of Revenue from the usage of Releases. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="MusicalWorkContributorRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A role played by a Contributor in relation to a MusicalWork.</xs:documentation>
+      </xs:annotation>
+      <xs:union memberTypes="avs:CreativeContributorRole avs:BusinessContributorRole"/>
+   </xs:simpleType>
+   <xs:simpleType name="MusicalWorkRightsClaimType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of RightsClaim related to a MusicalWork.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="CopyrightControl">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RightsClaim for a Work that is believed to be copyright, but its ownership is uncertain.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonMemberClaim">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RightsClaim in which a society makes no claim of ownership of control, because the controller of the RightShare in question is not represented by the society or any of its affiliated societies.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PublicDomain">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ownership or control by no specific Party. No RightsClaim can be made on Rights in a Creation which are in the public domain.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SocietyClaim">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RightsClaim made by a society on behalf of one or more of its members and/or affiliated societies.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="MusicalWorkType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of MusicalWork.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AdaptedInOriginalLanguage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork with its Lyrics modified but which remain in the original Language.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AdaptedInstrumentalWork">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork based on a pre-existing instrumental MusicalWork to which Lyrics have been added.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AdaptedWithNewLyrics">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork in which new Lyrics are added to existing Lyrics.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ArrangedWithNewMusic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork to which new music is added to existing music.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CompositeMusicalWork">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork made up of two or more MusicalWorks (in whole or in part).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DramaticoMusicalWork">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork composed of sounds with Lyrics and/or text to be performed by instruments and the human voice and to be performed in a dramatic context. Examples: opera, musical, play with music, revue or ballet.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LyricRemoval">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork in which Lyrics are removed to leave an instrumental Work.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LyricReplacement">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork in which Lyrics are completely replaced by new Lyrics.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LyricTranslation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork in which the original Lyrics are translated into another Language.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Mashup">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork whose expression is an overlaying of existing MusicalWorks or excerpts from MusicalWorks. Note: A Mashup typically results in the creation of a new piece of intellectual property.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Medley">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork whose expression is a combination of continuous and sequential existing MusicalWorks or excerpts from MusicalWorks. Note: A Medley does not normally result in the creation of a new copyright Work.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MultimediaProductionWork">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Work originally composed for use within a multimedia production not intended for broadcast. Examples: CDI, CD-ROM.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkMovement">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A self-contained Part of a MusicalWork. While individual or selected movements from a MusicalWork are sometimes performed separately, a Performance of the complete MusicalWork requires all  movements to be performed in succession.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkWithSamples">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork which contains new material and one or more excerpts of other MusicalWorks. The creation process for such MusicalWorks usually involves sampling the excerpts of the MusicalWorks from other SoundRecordings of those MusicalWorks.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicArrangement">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork (with or without Lyrics) in which musical elements have been taken from one or more other MusicalWork(s) and modified.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicArrangementOfText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork in which music is added to a pre-existing Text. Example: The song Auld Lang Syne composed to an earlier poem of the same name.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OriginalLyricsArrangement">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork based on another MusicalWork, in which the Lyrics are in their original form.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OriginalMusicAdaptation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork based on another MusicalWork, in which the musical elements are in their original form.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OriginalMusicalWork">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A first, independently created MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Potpourri">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork whose expression is a combination of existing MusicalWorks or excerpts from MusicalWorks to which typically, additional original material has been added. Example: material may be added to provide musical links joining or combining the existing MusicalWorks. Note: A Potpourri typically results in the creation of a new piece of intellectual property and is sometimes known as Mashup.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ProductionMusicLibraryWork">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Work recorded for use primarily in audio-visual productions or broadcasts.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RadioProductionWork">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Work specifically created for use in an AM/FM radio production.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TheaterProductionWork">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Work specifically created for use in a theatrical production.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TvProductionWork">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Work specifically created for use in a traditional television production.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UnspecifiedArrangement">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork which has been modified but where no specific arrangement Type is known.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UnspecifiedMusicalWorkExcerpt">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An excerpt from a MusicalWork, where the specifics of the excerpt are not known.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VideoProductionWork">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Work specifically created for use in a video production. Examples: self-help videos, educational videos, ...  </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="MwlCaCMessageInBatchType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Message in a batch in the Choreography for the Mechanical Licensing of Musical Works in Canada.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="LicenseOrClaimRequestMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Musical Work Licensing Message Suite Standard, which conveys information about a request for a License or Claim.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LicenseOrClaimMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Musical Work Licensing Message Suite Standard, which includes a License or Claim or a refusal thereof.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LicensingInformationRequestMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Musical Work Licensing Message Suite Standard, in which a (prospective) Licensee asks a (prospective) Licensor to provide additional information in order to enable the (prospective) Licensee to grant a License or make a Claim.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LicenseOrClaimConfirmationMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Musical Work Licensing Message Suite Standard, which conveys that a Licensee confirms or rejects a License or Claim received from a Licensor.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NewReleaseMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Release Notification Message Suite Standard, containing details of a new Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ContractDeliveryMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Choreography for the Mechanical Licensing of Musical Works in Canada that is sent to inform about a contract delivery.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ProductDeletionMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Choreography for the Mechanical Licensing of Musical Works in Canada that is sent to inform about a Product deletion.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="MwnMessageType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Message in the Electronic Musical Work Notification Message Suite.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="MusicalWorkClaimNotificationMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Electronic Musical Work Notification Message Suite Standard, containing details of one or more MusicalWork(s). The Message can also be used to communicate RightShares with respect to the reported MusicalWorks.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkClaimConflictNotificationMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Electronic Musical Work Notification Message Suite Standard, containing details of a rights conflict with respect to one or more MusicalWork(s). The Message is typically used by a Licensee to report conflicts to Licensors with a view to have the conflict resolved.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkClaimRequestMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Electronic Musical Work Notification Message Suite Standard, requesting claims for RightShares for one or more MusicalWork(s).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FtpAcknowledgementMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A default response Message in the Electronic Musical Work Notification Message Suite Standard that is sent to acknowledge the receipt of a manifest File via FTP. Note: the default message may be replaced by choreography-specific acknowledgement Messages.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ManifestMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message in the Electronic Musical Work Notification Message Suite Standard that is sent to document the FTP transfer of a batch of Messages.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="NewReleaseMessageStatus">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Status of a NewReleaseMessage.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="NewReleaseMessageNotProvided">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A NewReleaseMessageStatus indicating that a NewReleaseMessage is not provided.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NewReleaseMessageProvided">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A NewReleaseMessageStatus indicating that a NewReleaseMessage is provided.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="OperatingSystemType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of OperatingSystem.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="MacOS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An OperatingSystem developed by Apple Inc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MsWindows">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An OperatingSystem developed by Microsoft Corp.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Symbian">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An OperatingSystem developed by Symbian Ltd.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="OrderType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of order.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="BackCatalogOrder">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An OrderType in which the referenced Releases are back catalog Releases.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ExpressOrder">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An OrderType in which the referenced Releases should be procesed expeditioulsy.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HardDiskOrder">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An OrderType in which the referenced Releases have been provided on a hard disk to the MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MetadataOnlyOrder">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An OrderType in which only metadata and no Resources are delivered.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NewReleaseOrder">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An OrderType in which the referenced Releases are new Releases.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OffCycleRushOrder">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An OrderType in which the referenced Releases are new Releases. Their schedule is delayed, which makes it mandatory they have a higher priority than NewReleaseOrders.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PreOrder">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An OrderType in which the referenced Releases are have been pre-ordered by the DSP.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReDeliveryOrder">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An OrderType in which the referenced Releases are re-delivered.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TakeDownOrder">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An OrderType for a take-down of a specific Release that should be processed expeditioulsy.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="PLineType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of PLine.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="OriginalPLine">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A (P) RightsNotice for an original Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RemasteringPLine">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A (P) RightsNotice for a remastered Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ParentalWarningType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Creation according to advice which it carries about the level of explicitness or offensiveness of its content.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Explicit">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ParentalWarningType of a Creation which contains sexual, violent or other explicit material.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ExplicitContentEdited">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ParentalWarningType of a Creation in which sexual or other explicit material has been edited.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NoAdviceAvailable">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ParentalWarningType of a Creation for which no advice about sexual or other explicit content is available.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NotExplicit">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ParentalWarningType of a Creation which contains no sexual, violent or other explicit material.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="PartyRelationshipType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of relationship between two Parties.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string"/>
+   </xs:simpleType>
+   <xs:simpleType name="PercentageType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of PercentageRate.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="PercentageOfFreeGoodsPermitted">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A percentage of a number of free goods permitted.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PercentageOfGrossRevenue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A percentage of a gross Revenue.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PercentageOfNetRevenue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A percentage of a net Revenue.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PercentageOfNetSales">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A percentage of a number of net sales.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PercentageOfPriceConsumerPaid">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A percentage of a Price that a Consumer paid.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PercentageOfStatutoryRoyaltyRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A percentage of a statutory RoyaltyRate.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="PriceInformationType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Price for which information is provided.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="StandardRetailPrice">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A regular RetailPrice.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PreOrderPrice">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Price to be paid during a pre-order period.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="PriceRangeType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Price according to its value range.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string"/>
+   </xs:simpleType>
+   <xs:simpleType name="PriceType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Price.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string"/>
+   </xs:simpleType>
+   <xs:simpleType name="Priority">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of priority.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="High">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A high Priority.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Low">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A low Priority.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Normal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A medium Priority.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ProductType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Product.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AudioProduct">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Product that is predominantly comprised of AudioResources (SoundRecordings or MIDIs).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GraphicsProduct">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Product that is predominantly comprised of Images.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MixedMediaBundleProduct">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Product that is a bundle of different types of Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MobileProduct">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Product that is predominantly comprised of Products intended to be used on MobileTelephone devices.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VideoProduct">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Product that is predominantly comprised of Videos.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ProjectContributorRelationshipType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of relationship between a Project and a Contributor.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string"/>
+   </xs:simpleType>
+   <xs:simpleType name="Purpose">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of use that is the purpose of an action.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="BackgroundMusic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWorkSoundRecording used as background.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ChannelTrailerMusic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWorkSoundRecording used as a channel trailer.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Extract">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Fragment of a Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FilmTrailerMusic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWorkSoundRecording used as a film trailer.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ForegroundMusic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWorkSoundRecording used as foreground.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TrailerMusic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWorkSoundRecording used as a trailer.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RateModificationType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of a rate modification.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="MultipleDiscProvision">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description detailing reasons why a controlled composition clause applies, with special reference to multiple discs.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OtherProvision">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description detailing reasons why a controlled composition clause applies.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SalesVolumeProvision">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description detailing reasons why a controlled composition clause applies, with special reference to the sales volume.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VideoProvision">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description detailing reasons why a controlled composition clause applies, with special reference to the videos.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RatingAgency">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">An Organization that issues ParentalWarnings.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AFR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Alberta Film Ratings of Canada.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BBFC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The British Board of Film Classification of the United Kingdom.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BFCO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The British Columbia Film Classification Office of Canada.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BFSC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Board of Film and Stage Cassification of Malta.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BMUKK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Bundesministerium für Unterricht, Kunst und Kultur of Austria.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CBFC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Central Board of Film certification of India.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CCC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Consejo de Calificación Cinematográfica of Chile.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CCE">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Comissão de Classificação de Espectáculos of Portugal.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CHVRS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Canadian Home Video Rating System of Canada.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CNC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Commission de Classification of the CNC of France.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DJCTQ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Departamento de Justiça, Classificação, Títulos e Qualificação of Brazil.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Eirin">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Eirin of Japan.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FCB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Film Censorship Board of Malaysia.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Filmtilsynet">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Filmtilsynet of Norway.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FPB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Film and Publication Board of South Africa.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FSK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Freiwillige Selbstkontrolle der Filmwirtschaft of Germany.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IFCO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Irish Film Classification Office of Ireland.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="INCAA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Instituto de Cine y Artes Audiovisuales of Argentinia.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KMRB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Korea Media Rating Board of the Republic of Korea.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KR">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Kvikmyndaeftirlit Ríkisins of Iceland.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KRRIT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Krajowa Rada Radiofonii i Telewizj of Poland.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LSF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Lembaga Sensor Film of Indonesia.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MBU">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Medierådet for Børn og Unge of Denmark.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MDA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Media Development Authority of Singapore.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MDCB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The rating scheme used in Bulgaria.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MFCB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Manitoba Film Classification Board of Canada.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MIC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Ministry of Information and Culture of the UAE.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MPAA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Motion Pictura Association of America of the USA.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MTRCB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Movie and Television Review and Classification Board of the Philippines.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NBC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The National Bureau of Classification of the Maldives.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NFVCB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The National Film and Video Censors Board of Nigeria.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NICAM">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Kijkwijzer system executed by the NICAM of The Netherlands.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NKC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Nacionālais Kino Centrs of Latvia.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OFLC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Office of Film and Literature Classification of Australia.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OFLC-NZ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Office of Film and Literature Classification of New Zealand.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OFRB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Ontario Film Review Board of Canada.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RDCQ">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Régie du cinéma du Québec of Canada.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RTC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Dirección General de Radio, Televisión y Cinematografía of Mexico.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SBB">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Statens biografbyrå of Sweden.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Smais">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Smáís of Iceland.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SPIO-JK">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Spitzenorganisation der Filmwirtschaft of Germany.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TELA">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Television and Entertainment Licensing Authority of Hong-Kong.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VET">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Valtion elokuvatarkastamo of Finnland.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ReasonType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of reason.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="ChartReporting">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Reporting of SalesTransactions for the purpose of compiling charts.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RoyaltyReporting">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Reporting of SalesTransactions for the purpose of calculate royalties for them.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RecipientRevenueType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of revenue according to the recipient of the payment.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="PerformerAndProducerRevenue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Revenue of a Performer and Producer.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PerformerRevenue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Revenue of a Performer.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ProducerRevenue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Revenue of a Producer.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RecordingMode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A mode of a Recording.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Mono">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A mono RecordingMode.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MultichannelAudio">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SoundRecording made in multichannel audio mode.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Stereo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A stereo RecordingMode.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RedeliveryReasonType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A reason for a redelivery.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="BinaryCorrupted">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RedeliveryReasonType indicating that the MessageSender has detected that a Resource received is corrupt.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MetadataInadequate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RedeliveryReasonType indicating that the MessageSender has detected that the metadata describing a Deal or Release (or part thereof) is inadequate.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PackageIncomplete">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RedeliveryReasonType indicating that the MessageSender has detected that some files that made up the original delivery of the Release were not (successfully) communicated.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ProcessingErrorAtReleaseDistributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RedeliveryReasonType indicating that the MessageSender has detected some processing error at the ReleaseDistributor that stopped the ReleaseDistributor from making the Release available.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ReferenceUnit">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A unit to which a Quantity refers.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="PerLicense">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReferenceUnit of a Quantity that refers to a whole License.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PerUse">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReferenceUnit of a Quantity that refers to a usage.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RelationalRelator">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Relator between two Entities expressing a measurable relationship.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="EqualTo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Relator between an Entity and another to which it is exactly equivalent.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LessThan">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Relator between a quantity and another which is larger.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LessThanOrEqualTo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Relator between a quantity and another which is larger than or equal to it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MoreThan">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Relator between a quantity and another which is smaller.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MoreThanOrEqualTo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Relator between a quantity and another which is smaller than or equal to it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NotEqualTo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Relator between an Entity and another to which it is not equivalent.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ReleaseAvailabilityStatus">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Status of the availability of a Release.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AvailableForDSP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseAvailabilityStatus indicating that a Release is available for a DSP.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NotAvailableForDSP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseAvailabilityStatus indicating that a Release is not available for a DSP.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NotClearedForDSP">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseAvailabilityStatus indicating that a Release is not cleared for a DSP.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NotClearedForTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseAvailabilityStatus indicating that a Release is not cleared for a Territory.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NotYetPrepared">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseAvailabilityStatus indicating that a Release is, in principle, available for a DSP, but is still in the processing stages and will become available soon.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ReleaseRelationshipType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of relationship between two Releases.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="HasArtistFromEnsemble">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of a Release where the related Release is by an Ensemble that contains the Artist of the present Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HasArtistFromSameEnsemble">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of a Release which is by an Artist of the same Ensemble as the Artist of another Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HasEnsembleWithArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of a Release where the related Release is by an Artist who is part of the Ensemble that created the present Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HasSameArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of a Release which is by the same Artist as another Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HasSameRecordingProject">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of a Release which is from the same recording project as another Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HasSimilarContent">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of a Release which is largely equivalent to one or more other Releases which may have a different ResourceType (e.g. a video Release corresponding to an AudioRelease).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IsDigitalEquivalentToPhysical">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of a digital Release that is equivalent to a PhysicalProduct (i.e. it is materially the same, where any difference is not material for marketing a Release to the Consumer or for reporting).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IsEquivalentToAudio">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of a video Release that is equivalent to an AudioRelease (i.e. it is materially the same, where any difference is not material for marketing a Release to the Consumer or for reporting).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IsEquivalentToVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of an AudioRelease that is equivalent to a video Release (i.e. it is materially the same, where any difference is not material for marketing a Release to the Consumer or for reporting).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IsExtendedFromAlbum">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of an Album that is a different version of another Album and that has additional Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IsFromAudio">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of a Release that has been taken from a different AudioRelease.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IsFromVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of a Release that has been taken from a different video Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IsParentRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of a Release that has been used for another Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IsPhysicalEquivalentToDigital">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of a PhysicalProduct that is equivalent to a digital Release (i.e. it is materially the same, where any difference is not material for marketing a Release to the Consumer or for reporting).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IsReleaseFromRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of a Release that has been taken from a different Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IsShortenedFromAlbum">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseRelationshipType of an Album that is a different version of another Album, but has less Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ReleaseResourceType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Resource in the context of a Release.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="PrimaryResource">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Resource that is a main Resource of a Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SecondaryResource">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Resource that is not a main Resource of a Release. It supports the PrimaryResources (examples are lyrics, cover art etc). In accordance with the GRid standard, a change in a PrimaryResource mandates a new GRid wheras a change in a SecondaryResource does not mandate a new GRid.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ReleaseType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Release according to its content, Duration and/or number of components. Note: a ReleaseType is the form in which a ReleaseCreator anticipates offering a Release to Consumers.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AdvertisementVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video created for specifically to promote another Video, embodying a MusicalWork. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Album">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release that is a digital equivalent of a physical SoundCarrier of an extended Duration, typically containing multiple Tracks of SoundRecordings. It may also contain bonus Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AlertToneRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing a Resource for use as an AlertTone primarily on MobileTelephones.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Animation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording using a rapid display of a sequence of images of 2-D or 3-D artwork or model positions in order to create an illusion of movement.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AsPerContract">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a MessageSender wishes to indicate that the value within the allowed value set is defined by the contractual relationship between MessageSender and MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AudioBookRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing, chiefly, one or more Recordings of the reading of a book or manuscript.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AudioClipRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release predominantly containing excerpts from SoundRecordings.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BackCoverImageRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing an Image Resource that, in the physical equivalent Product, is a back cover image.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BookletBackImageRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing an Image Resource that, in the physical equivalent Product, is a back image of a booklet.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BookletFrontImageRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing an Image Resource that, in the physical equivalent Product, is a front image of a booklet.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BookletRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing an Image Resource that, in the physical equivalent Product, is a booklet.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Bundle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A set comprising more than one Resource of different ResourceTypes compiled for release. Bundles are typically used in electronic distribution. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ClassicalAlbum">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Album that contains one or more SoundRecordings based on classical MusicalWorks, i.e. MusicalWorks that typically shows a hierarchy of components such as a concerto with multiple movements.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ConcertVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video recording of a live Performance, usually of music, before an audience. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorporateFilm">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording made for use within a corporate entity. Examples include company-internal training videos.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DigitalBoxSetRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release consisting of a media bundle assembled out of other existing Albums. It may contain a mixture of both audio and video Albums, as well as bonus material. The bundled Albums become components
+within the digital boxed sets resource group structure. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Documentary">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording that presents a social, political, scientific or historical subject. Documentaries include current affairs programmes, TV magazines, biographies and 'making of' programs.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DocumentImageRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing an Image Resource that, in the physical equivalent Product, is a document.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="EBookRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release typically for use as an EBook.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Episode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Part of a Series made available at a specific point in time. It may be that a Season or Series is not yet complete when an Episode is made available. Episodes include 'pilots'.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FeatureFilm">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording made for initial distribution in cinemas, where it would be the 'main attraction' of the screening, or prime-time television.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FilmBundle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Bundle whose core Resources are Videos, but that may also contain Resources of different ResourceTypes. FilmBundles are typically used in electronic distribution.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FrontCoverImageRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing an Image Resource that, in the physical equivalent Product, is a front cover image.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IconRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing an Image Resource, that is typically used as pictogram in graphical user interfaces, to represent the Release or a Resource or Party related to the Release, and which can be selected to perform a function.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="InfomercialVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video created for specifically to promote another Video, embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="InteractiveBookletRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release typically for use as an InteractiveBooklet.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KaraokeRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release typically for use in Karaoke applications.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LiveEventVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording capturing an Event such as a sporting event, theatrical performances, etc. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LogoRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing an Image Resource, that is typically used as a logo to represent parties associated with the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LongFormMusicalWorkVideoRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more LongFormMusicalWorkVideo Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LongFormNonMusicalWorkVideoRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more LongFormNonMusicalWorkVideo Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LyricSheetRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more lyric sheet Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MultimediaAlbum">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A multimedia Release typically containing multiple  Resources of different ResourceTypes. It may also contain bonus Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MultimediaSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A multimedia Release with a short total Duration, typically containing two Resources of different ResourceTypes.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkBasedGameRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more MusicalWorkBasedGame Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkClipRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more MusicalWorkClip Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkReadalongVideoRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more MusicalWorkReadalongVideo Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkTrailerRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more MusicalWorkTrailer Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkVideoChapterRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more MusicalWorkVideoChapter Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="News">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording, usually regularly scheduled, which reports current events.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonMusicalWorkBasedGameRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more NonMusicalWorkBasedGame Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonMusicalWorkClipRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more NonMusicalWorkClip Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonMusicalWorkReadalongVideoRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more NonMusicalWorkReadalongVideo Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonMusicalWorkTrailerRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more NonMusicalWorkTrailer Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonMusicalWorkVideoChapterRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more NonMusicalWorkVideoChapter Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonSerialAudioVisualRecording">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording that is not part of a Series or Season.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PhotographRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more Photograph Image Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RingbackToneRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing a Resource for use as an RingbackTone primarily on MobileTelephones.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RingtoneRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing a Resource for use as an Ringtone primarily on MobileTelephones.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ScreensaverRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing a Resource for use as a Screensaver.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Season">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Set of Episodes. Typically, a Season contains all Episodes to be made available in a pre-determined time frame, which often is within a twelve-month period. It may be that a Series is not yet complete when an Season is made available.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Series">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Set of Resources (Episodes) designed to be made available sequentially.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SheetMusicRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more Resources representing sheet music.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ShortFormMusicalWorkVideoRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more ShortFormMusicalWorkVideo Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ShortFormNonMusicalWorkVideoRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more ShortFormNonMusicalWorkVideo Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Single">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release with a short total Duration, typically containing one or two Tracks of SoundRecordings.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SingleResourceRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing a single Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SingleResourceReleaseWithCoverArt">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing a single primary Resource, augmented by a single cover art image.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TrackRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing normally one SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TrailerVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video created for specifically to promote another Video, embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TrayImageRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing an Image Resource that, in the physical equivalent Product, is a TrayImage.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VideoAlbum">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release typically containing multiple Video Tracks. It may also contain bonus Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VideoChapterRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more LongFormNonMusicalWorkVideo Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VideoClipRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release predominantly containing excerpts from Videos.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VideoScreenCaptureRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing typically one or more VideoScreenCapture Image Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VideoSingle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release with a short total Duration, typically containing one or two ShortFormVideos.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VideoTrackRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing normally one Video.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WallpaperRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release containing a Resource for use as a Wallpaper.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ReportFormat">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of report according to its FileFormat.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="ASCII">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">American Standard Code for Information Interchange as defined in ISO 464.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CSV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Comma-Separated Values as specified by IETF.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Excel2000">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Excel 2000 as defined by Microsoft.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Excel2007">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Excel 2007 as defined by Microsoft.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Excel2010">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Excel 2010 as defined by Microsoft.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="XML">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Extensible Markup Language as defined by W3C.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ReportType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of report.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="DeliveryFrequencyRequestCall">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Communication in the ERN Choreography (ERN-C) regarding a change in the delivery frequency of ERN Messages.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="InformationAboutDeliveredAndAvailableReleasesCall">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Communication in the ERN Choreography (ERN-C) regarding information, from a ReleaseDistributor, about an available Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OrderedReleasesInQueueRequestCall">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Communication in the ERN Choreography (ERN-C) regarding information about selected Releases ordered for delivery.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RedeliveryRequestCall">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Communication in the ERN Choreography (ERN-C) regarding a redelivery of Resources, Releases or ReleaseDeals.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReleaseAvailabilityCall">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Communication in the ERN Choreography (ERN-C) regarding the availability of a Release or ReleaseDeal.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReleaseAvailabilityRequestCall">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Communication in the ERN Choreography (ERN-C) regarding a request for the availability of a Release or ReleaseDeal.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReleaseStatusInformationCall">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Communication in the ERN Choreography (ERN-C) regarding information, from a ReleaseDistributor, about the status of a Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReleaseStatusRequestCall">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Communication in the ERN Choreography (ERN-C) regarding the request for information, from a ReleaseDistributor, about the status of a Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReleaseSupplyChainRequestCall">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Communication in the ERN Choreography (ERN-C) regarding the status of a Release or ReleaseDeal in a supply chain.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReportDeliveryCall">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Communication in the ERN Choreography (ERN-C) regarding a delivery of a report.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReportRequestCall">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Communication in the ERN Choreography (ERN-C) regarding a report request.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SupplyChainStatusCall">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Communication in the ERN Choreography (ERN-C) regarding the status of a supply chain.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RequestReason">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of reason for requesting something.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RequestedActionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of action requested.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AdditionalInformationOnly">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is described only in an AdditionalInformation element.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectAndInform">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A request to correct the data and inform any data providers. No need to inform the sender of the DataMismatchMessage.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorrectAndResend">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A request to correct the data and resend the data to the sender of the DataMismatchMessage.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NoAction">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">No specific further action is requested.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ResourceContributorRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A role played by a Contributor in relation to a Fixation of an abstract Creation.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Actor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who performs spoken word or mime.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Architect">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Designer of a building.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Artist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A principal Contributor to a Performance of a MusicalWork or a NonMusicalWork that results in the creation of a Resource. Note: Used for naming groups as well as individuals.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AssociatedPerformer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Artist commonly associated with a Work as one of its Performers, and whose identity is only used for accurate Work identification.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Band">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A group of individuals who perform vocally and/or instrumentally together.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BookPublisher">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Publisher of books.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Cartoonist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a cartoon.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Choir">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A group of Parties who perform vocally together. Typically, Choirs consist of at least 2 people in an combination of different vocal ranges.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Choreographer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a dance.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ComputerGraphicCreator">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a computer graphics.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Conductor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who leads or conducts a Performance by a group of musicians.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Contributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party contributing to the making of a Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CostumeDesigner">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Designer of a costume.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Designer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a design.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Dubber">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator who adds the dubbing into a Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Encoder">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator processing and encoding a Resource for distribution.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Ensemble">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A group of two or more Parties performing a MusicalWork together. Note: An Ensemble may be of any size or any grouping of Performers from a vocal duo to a full orchestra.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FeaturedArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who is not the MainArtist but is acknowledged as a significant Contributor to the Performance. Note: FeaturedArtists are often MainArtists on their own Resources. They are also frequently credited on marketing material using the term 'featuring ...'.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FilmDirector">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Director of a movie.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FilmDistributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Publisher of films.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FilmEditor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who edits an audio-visual production for publishing.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FilmProducer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party (individual or company) that is responsible for the financing of an audio-visual production.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FilmSoundEngineer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party that is responsible for (part of) the soundtrack used in an audio-visual Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GraphicArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a drawing.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GraphicDesigner">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Designer of graphical elements.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Journalist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of an article for a magazine or a newspaper.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MainArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who is a principal credited Artist for a Resource. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Member">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Person that is a member of a Group.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Narrator">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who tells a story or gives an account of an event.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NewspaperPublisher">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Publisher of newspapers.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Orchestra">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A large group of Parties performing a MusicalWork together, predominantly using musical instruments rather than voice. An Orchestra is typically led by a Conductor.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Painter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a painting.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PeriodicalPublisher">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Publisher of periodicals (e.g. magazines, journals).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Photographer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a photograph.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PhotographyDirector">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Director of responsible for photography.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PrimaryMusician">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who performs a MusicalWork either vocally or instrumentally and would be considered the principal Contributor for the piece.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Producer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party responsible for an artistic input to the production of a Resource (e.g. a SoundRecording or audiovisual Recording).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Programmer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a computer program.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RightsControllerOnProduct">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RightsController as it appears on a product.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ScreenplayAuthor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creator of a screenplay.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SetDesigner">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Designer of a setting for a scene.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Soloist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who performs the featured Part of a MusicalWork (or a section of it) alone or with only supporting accompaniment. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="StageDirector">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Director of a stageplay.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="StudioPersonnel">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who is employed in a studio and contributes to the making of a Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SubtitlesEditor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party that is responsible for the creation of SubTitles/captions.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SubtitlesTranslator">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Translator of SubTitles.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ResourceOmissionReason">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of reason for omitting a Resource.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="PassportServiceRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release defining a 'passport' service where Resources are added over time.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PreRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release made available to a ReleaseDistributor before the official release to Consumers.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VirtualRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Release provided without Resources to a ReleaseDistributor, who then adds Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ResourceType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Resource.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Image">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A still visual Recording or illustration of an object. Examples: a Photograph or a GraphicImage.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MIDI">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Set of computer instructions which enables a sound processor to generate sounds (using the Musical Instrument Digital Interface as defined by the MIDI Manufacturers Association (MMA)).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SheetMusic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A hand-written or printed form of musical notation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Software">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A program that enables a Computer to perform a specific task(s).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SoundRecording">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio Recording.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Text">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A written Manifestation. Examples: the Lyrics of a MusicalWork or the Text of an interview.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefinedResource">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Resource which is UserDefined.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Video">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RevenueSourceType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of revenue earned by the SoundRecording, according to the way the revenue is generated.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="FinancialRevenue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Revenue from financial interest. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IndemnityRevenue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Revenue generated by indemnities. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RoyaltyRevenue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Revenue generated by Royalties.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RightShareRelationshipType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of relationship between two RightShares.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string"/>
+   </xs:simpleType>
+   <xs:simpleType name="RightShareType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of RightShare.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="MusicalWorkManuscriptShare">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RightShare of a MusicalWork as agreed between the writers. The sum of all MusicalWorkManuscriptShares on a MusicalWork equals 100%. It is possible (though unusual) for MusicalWorkManuscriptShares to vary by Territory or Rights Type. Manuscript Shares are often referred to as Writer Shares.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkCollectionShare">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RightShare as calculated for the collection of money for RightShares.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OriginalPublisherShare">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RightShare owned by the OriginalPublisher (i.e. the MusicPublisher who has been given the rights by the writer, as opposed to by another Publisher) of the MusicalWork. They are also referred to as Stakeholder Shares or Primary Publishers Shares.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RightsClaimPolicyType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of rights claim policy.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="ReportUsage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A policy where the recipient of the message shall report any use of a Release or Resource that meets the condition to the relevant rights holder(s).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BlockAccess">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A policy where the recipient of the message shall block any use of a Release or Resource that meets the condition.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Monetize">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A policy where the recipient of the message may make the Release or Resource that meets the condition available for commercial purposes and shall report revenues to the relevant rights holder(s).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RightsControllerRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A role of a RightsController.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AdministratingRecordCompany">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party responsible for administering Rights in a Resource or Release. Note: This role does not entail any ownership or control of the exploitation of Rights, although the same Party may also be an owner or controller of Rights in that way.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RightsAdministrator">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party administrating Rights on behalf of one or more RightsControllers.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party who owns and/or controls Rights in a MusicalWork and/or a Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RoyaltyAdministrator">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Party that collects and distributes Royalties on behalf of one or more RightsControllers.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RightsControllerType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of a RightsController.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="OriginalOwner">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RightsController who owns and/or controls the original Rights in a MusicalWork and/or a Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SuccessorInTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RightsController who is a successor in title.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ExclusiveLicensee">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An exclusive Licensee.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RightsCoverage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Right which is covered.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="MakeAvailableRight">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Right to make a Work available to the public.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MechanicalRight">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Right to record and distribute a Work on a Carrier.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PerformingRight">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Right to perform a Work. This is, to present a Work by action such as playing, reciting, singing, or projecting to the public in their presence.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PrintRight">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Right to make a visual copy of a Work (and distribute it).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReproductionRight">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Right to make a physical reproduction of a Work.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SynchronizationRight">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Right to include and combine a Work either completely or in parts in timed relation with Works of other types for the making of an audio-visual or multimedia Creation or a database.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RoyaltyRateCalculationType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of RoyaltyRate according to the calculation method.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="BudgetRoyaltyRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RoyaltyRate for Products classified as 'budget'.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ControlledCompositionRoyaltyRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RoyaltyRate calculated through provisions of a contract containing a 'controlled composition' clause.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ControlledShareRoyaltyRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A controlled RoyaltyRate applied to a RightShare in a Work.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MinimumStatutoryRoyaltyRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A minimum statutory RoyaltyRate.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NegotiatedRoyaltyRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RoyaltyRate negotiated between individual Licensor and Licensee. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReducedRoyaltyRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A reduced RoyaltyRate.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReducedStatutoryRoyaltyRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A reduced StatutoryRoyaltyRate.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="StatutoryRoyaltyRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A statutory RoyaltyRate.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="RoyaltyRateType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of RoyaltyRate.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="PennyRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RoyaltyRate in absolute monetary terms.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PercentageRoyaltyRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A percentage or value Rate at which royalties are due, representing the percentage of some Amount (e.g., RetailPrice) payable in royalties.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="SalesReportAvailabilityStatus">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Status of the availability of a sales report.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="SalesReportAvailable">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SalesReportAvailabilityStatus indicating that a sales report is currently available.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SalesReportNotAvailable">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SalesReportAvailabilityStatus indicating that no sales report is currently available.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="Sex">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">The biological sex of a being.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Female">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A female Sex.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Male">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A male Sex.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="SheetMusicCodecType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of SheetMusicCodec.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string"/>
+   </xs:simpleType>
+   <xs:simpleType name="SheetMusicType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of SheetMusic.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string"/>
+   </xs:simpleType>
+   <xs:simpleType name="SoftwareType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Software.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="InteractiveBooklet">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Software providing access, by using technology that provides User interaction, to Resources which add user value to the Release. This is often, but not always, related to the packaging of the PhysicalProduct.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkBasedGame">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Game Software, containing sounds which do not embody a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonMusicalWorkBasedGame">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Game Software, containing sounds which embody a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Screensaver">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Software application which is a screensaver for a display (e.g. on a mobile phone) or monitor (e.g. on a PersonalComputer).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="SoundProcessorType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of sound processor.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="MidiProcessor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A sound processor using the Musical Instrument Digital Interface as defined by the MIDI Manufacturers Association (MMA).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SMAF-MA2">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Synthetic-music mobile application format specified by Yamaha for portable electronic devices, Version 2.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SMAF-MA3">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Synthetic-music mobile application format specified by Yamaha for portable electronic devices, Version 3.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="SoundRecordingType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of SoundRecording.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="MusicalWorkReadalongSoundRecording">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SoundRecording to read along to, and interact with, stories and songs, embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkSoundRecording">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SoundRecording embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonMusicalWorkReadalongSoundRecording">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SoundRecording to read along to, and interact with, stories and songs, not embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonMusicalWorkSoundRecording">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SoundRecording which does not embody a MusicalWork. Examples: a SoundRecording of an Artist interview or a monologue.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SpokenWordSoundRecording">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SoundRecording containing spoken words with or without background music.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="SupplyChainStatus">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Status of a Release in a supply chain.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="DeliveredToReleaseDistributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SupplyChainStatus indicating that a Release has been delivered to the ReleaseDistributor.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="InDeliveryToReleaseDistributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SupplyChainStatus indicating that a Release is currently being delivered to the ReleaseDistributor.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="InPreparationForDeliveryToReleaseDistributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SupplyChainStatus indicating that a Release is currently being prepared to be delivered to the ReleaseDistributor.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OrderPlacedForReleaseDistributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SupplyChainStatus indicating that an order for delivery has been placed with the ReleaseCreator.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ProcessingErrorAtReleaseCreator">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SupplyChainStatus indicating that the ReleaseCreator has encountered a processing error with respect to the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ProcessingErrorAtReleaseDistributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SupplyChainStatus indicating that the ReleaseDistributor has encountered a processing error with respect to the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReleaseMadeAvailableToConsumers">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SupplyChainStatus indicating that a Release has been made available to Consumers.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReleaseNotAvailable">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SupplyChainStatus indicating that a Release is currently not available from the ReleaseCreator.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReleaseReceivedByReleaseDistributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SupplyChainStatus indicating that a Release has been received by the ReleaseDistributor.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ReleaseStagedForPublication">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SupplyChainStatus indicating that a Release has been staged for publication by the ReleaseCreator.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SuccessfullyIngestedByReleaseDistributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SupplyChainStatus indicating that a Release has been successfully ingested by the ReleaseDistributor.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="TaxScope">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Tax according to its scope.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="CombinedTax">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Tax which is a combination of several Taxes.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FederalTax">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Tax which applies at the federal level.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LocalTax">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Tax which applies locally.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ProvincialTax">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Tax which applies at the provincial level.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="StateTax">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Tax which applies at the state level.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="TaxType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Tax.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="CombinedTax">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Tax which is a combination of several Taxes.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SalesTax">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Tax which is applicable to an Amount paid for a Product by an end Customer.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ServiceTax">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Tax which has to be paid for services.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SourceTax">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Tax which is applicable to an Amount at the source of the transaction.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="TerritoryCodeType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of code.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="ISO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A StandardIdentifier according to ISO 3166-1 Alpha 2 standard (or WorldWide). This is the default value.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TIS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A StandardIdentifier according to CISAC's Territory Information System.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="TerritoryCodeTypeIncludingDeprecatedCodes">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of code which also includes deprecated codes.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="DeprecatedISO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A StandardIdentifier according to ISO 3166-3 standard. Note: these codes are four-letter codes.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ISO">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A StandardIdentifier according to ISO 3166-1 Alpha 2 standard (or WorldWide). This is the default value.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TIS">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A StandardIdentifier according to CISAC's Territory Information System.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="TextCodecType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of TextCodec.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="ASCII">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">American Standard Code for Information Interchange as defined in ISO 464.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="EBU-TT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The EBU-TT format for subtitling data exchange (based on TTML), as defined by the European Broadcasting Union (aka EBU 3264).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="HTML">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">HyperText Markup Language as defined by W3C.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OOXML">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Office Open XML for the representation of texts as defined in ISO/IEC 29500 (also known as Microsoft Word XML format).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PDF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Portable Document Format as defined by Adobe.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PostScript">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Postscript as defined by Adobe.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RTF">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Rich Text Format as defined by Microsoft.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SRT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The SRT format as developed by SubRip.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TTML">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Timed Text Markup Language, a coding format used for Captions,  as defined by W3C.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VTT">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Web Video Text Tracks format used for Captions, as defined by W3C.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="TextType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Text.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Caption">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Resource that contains the text to be shown as subtitles, including closed or open captioning, as well as timing information</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="EBook">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A digital equivalent of a conventionally printed book.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LinerNotes">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Text included with a SoundCarrier, in the physical world typically in its sleeve or packaging. Example: a mix of factual, anecdotal and discographic material.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LyricText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Text consisting of the words of a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonInteractiveBooklet">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Text of a small book usually in reference to the packaging relating to a physical Creation which does not use technology that provides User interaction.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TextDocument">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A written Text intended to communicate or store collections of data.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ThemeType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Theme.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="ClosingTheme">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Theme used in the final moments of the containing Resource, Collection or Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MainTheme">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Theme used throughout the containing Resource, Collection or Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OpeningTheme">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Theme used in the introduction of the containing Resource, Collection or Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SegmentTheme">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Theme used during a part of the containing Resource, Collection or Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TitleTheme">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Theme used during the display of title of the containing Resource, Collection or Release.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="TisTerritoryCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A CISAC four-digit TIS code representing a Territory.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="4">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Afghanistan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="8">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Albania (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="12">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Algeria (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="20">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Andorra (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="24">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Angola (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="28">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Antigua And Barbuda (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="31">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Azerbaijan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="32">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Argentina (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="36">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Australia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="40">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Austria (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="44">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bahamas (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="48">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bahrain (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="50">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bangladesh (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="51">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Armenia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="52">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Barbados (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="56">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Belgium (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="64">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bhutan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="68">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bolivia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="70">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bosnia And Herzegovina (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="72">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Botswana (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="76">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Brazil (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="84">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Belize (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="90">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Solomon Islands (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="96">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Brunei Darussalam (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="100">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bulgaria (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="104">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Myanmar (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="108">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Burundi (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="112">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Belarus (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="116">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cambodia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="120">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cameroon (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="124">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Canada (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="132">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cape Verde (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="140">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Central African Republic (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="144">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sri Lanka (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="148">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Chad (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="152">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Chile (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="156">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">China (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="158">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Taiwan, Province of China (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="170">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Colombia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="174">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Comoros (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="178">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Congo (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="180">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Congo, The Democratic Republic of The (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="188">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Costa Rica (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="191">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Croatia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="192">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cuba (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="196">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cyprus (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="200">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Czechoslovakia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="203">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Czech Republic (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="204">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Benin (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="208">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Denmark (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="212">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Dominica (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="214">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Dominican Republic (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="218">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ecuador (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="222">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">El Salvador (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="226">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Equatorial Guinea (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="230">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ethiopia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="231">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ethiopia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="232">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Eritrea (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="233">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Estonia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="242">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Fiji (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="246">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Finland (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="250">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">France (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="258">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">French Polynesia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="262">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Djibouti (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="266">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Gabon (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="268">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Georgia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="270">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Gambia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="276">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Germany (after 1990) (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="278">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">German Democratic Republic (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="280">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Germany (before 1990) (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="288">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ghana (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="296">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kiribati (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="300">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Greece (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="308">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Grenada (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="320">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guatemala (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="324">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guinea (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="328">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guyana (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="332">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Haiti (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="336">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Holy See (Vatican City State) (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="340">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Honduras (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="344">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hong Kong (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="348">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hungary (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="352">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Iceland (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="356">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">India (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="360">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Indonesia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="364">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Iran, Islamic Republic of (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="368">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Iraq (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="372">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ireland (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="376">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Israel (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="380">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Italy (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="384">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Cote D'Ivoire (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="388">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Jamaica (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="392">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Japan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="398">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kazakhstan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="400">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Jordan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="404">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kenya (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="408">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Korea, Democratic People's Republic of (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="410">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Korea, Republic of (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="414">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kuwait (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="417">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Kyrgyzstan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="418">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lao People's Democratic Republic (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="422">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lebanon (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="426">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lesotho (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="428">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Latvia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="430">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Liberia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="434">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Libya (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="438">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Liechtenstein (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="440">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Lithuania (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="442">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Luxembourg (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="450">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Madagascar (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="454">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Malawi (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="458">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Malaysia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="462">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Maldives (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="466">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mali (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="470">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Malta (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="478">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mauritania (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="480">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mauritius (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="484">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mexico (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="492">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Monaco (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="496">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mongolia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="498">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Moldova, Republic of (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="499">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Montenegro (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="504">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Morocco (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="508">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Mozambique (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="512">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Oman (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="516">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Namibia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="520">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nauru (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="524">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nepal (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="528">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Netherlands (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="540">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">New Caledonia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="548">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Vanuatu (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="554">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">New Zealand (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="558">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nicaragua (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="562">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Niger (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="566">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nigeria (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="578">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Norway (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="583">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Micronesia, Federated States of (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="584">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Marshall Islands (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="585">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Palau (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="586">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pakistan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="591">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Panama (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="598">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Papua New Guinea (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="600">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Paraguay (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="604">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Peru (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="608">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Philippines (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="616">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Poland (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="620">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Portugal (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="624">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Guinea-Bissau (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="626">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Timor-Leste (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="630">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Puerto Rico (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="634">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Qatar (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="642">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Romania (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="643">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Russian Federation (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="646">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Rwanda (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="659">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saint Kitts And Nevis (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="662">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saint Lucia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="670">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saint Vincent And The Grenadines (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="674">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">San Marino (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="678">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sao Tome And Principe (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="682">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Saudi Arabia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="686">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Senegal (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="688">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Serbia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="690">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Seychelles (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="694">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sierra Leone (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="702">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Singapore (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="703">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Slovakia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="704">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Viet Nam (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="705">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Slovenia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="706">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Somalia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="710">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">South Africa (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="716">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Zimbabwe (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="720">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Yemen, Democratic (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="724">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Spain (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="728">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">South Sudan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="729">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sudan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="732">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Western Sahara (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="736">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sudan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="740">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Suriname (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="748">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Swaziland (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="752">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Sweden (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="756">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Switzerland (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="760">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Syrian Arab Republic (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="762">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tajikistan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="764">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Thailand (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="768">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Togo (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="776">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tonga (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="780">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Trinidad And Tobago (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="784">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">United Arab Emirates (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="788">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tunisia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="792">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Turkey (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="795">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Turkmenistan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="798">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tuvalu (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="800">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Uganda (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="804">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Ukraine (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="807">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Macedonia, The Former Yugoslav Republic of (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="810">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">USSR (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="818">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Egypt (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="826">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">United Kingdom (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="834">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Tanzania, United Republic of (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="840">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">United States (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="854">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Burkina Faso (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="858">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Uruguay (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="860">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Uzbekistan (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="862">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Venezuela (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="882">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Samoa (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="886">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Yemen (before 1990) (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="887">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Yemen (after 1990) (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="890">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Yugoslavia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="891">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Serbia And Montenegro (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="894">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Zambia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2100">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Africa (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2101">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">America (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2102">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">American Continent (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2103">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Antilles (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2104">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Apec Countries (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2105">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Asean Countries (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2106">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Asia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2107">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Australasia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2108">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Balkans (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2109">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Baltic States (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2110">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Benelux (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2111">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">British Isles (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2112">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">British West Indies (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2113">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Central America (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2114">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Commonwealth (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2115">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Commonwealth African Territories (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2116">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Commonwealth Asian Territories (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2117">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Commonwealth Australasian Territories (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2118">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Commonwealth of Independent States (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2119">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Eastern Europe (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2120">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Europe (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2121">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">European Economic Area (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2122">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">European Continent (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2123">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">European Union (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2124">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">GSA Countries (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2125">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Middle East (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2126">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nafta Countries (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2127">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Nordic Countries (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2128">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">North Africa (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2129">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">North America (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2130">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Oceania (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2131">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Scandinavia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2132">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">South America (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2133">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">South East Asia (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2134">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">West Indies (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="2136">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">World (Source: TIS Standard).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="TitleType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Title which defines its origin, form or the function it fulfils in relation to a Creation. Note: A Title may fulfil more than one role. Example: 'Help' may be both the OriginalTitle and the DisplayTitle for the well-known Beatles song.  </xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AbbreviatedDisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A shortened version of the DisplayTitle which may be used for devices that have limited display capability.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AlternativeTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An alternative to the ReferenceTitle. Example: a song may become well known or 'also known as (a.k.a.)' by its first line or a line from its chorus: 'Don't Stop Me Now' performed by Queen may have an AlternativeTitle 'Having A Good Time' or, 'I will always love you' performed by Whitney Houston may have an AlternativeTitle of 'Theme from Bodyguard'.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Title expressed by the RightsController as to how a Title should be displayed for presentation to the Consumer.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FirstLineOfText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Title which consists of the first line of the text of which it is a Title.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FormalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Title structured according to a naming convention.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GroupingTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Title given to a grouping of Creations. Example: 'Stadium Arcadium' by Red Hot Chilli Peppers is a GroupingTitle for their Product because it contains two Products which are each separately named 'Saturn' and 'Mars'.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="IncorrectTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Title by which a Creation is often incorrectly known.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MisspelledTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Title that contains common typographic errors.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OriginalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Title given to a Creation by its Creator(s), in its original Language. Note: A Creation may be given more than one OriginalTitle. Note: The OriginalTitle of a Creation X may be the ReferenceTitle of a Creation that X is based on. Example: the OriginalTitle of the MusicalWork 'My Way' (written by Paul Anka) is 'Comme d'habitude' (written by Claude François).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SearchTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Title created to aid database searching (for example, where special characters, puns, or slang have been replaced by standardized elements).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SortingTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Title which has been arranged such that it can be used for alphabetic sorting.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TitleAsPart">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Title of a Creation as Part of another Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TitleWithoutPunctuation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Title from which all initial articles and punctuation have been removed.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TranslatedTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A translation into a different Language of the value contained in an OriginalTitle Element. Note: this is not the same as the OriginalTitle of a translation of a Creation, though the two will often be represented by the same text string. Example: the TranslatedTitle of 'Le Nozze di Figaro' is 'The Marriage Of Figaro'. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="TrackContributorRelationshipType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of relationship between a Track and a Contributor.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string"/>
+   </xs:simpleType>
+   <xs:simpleType name="UnitOfBitRate">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A UnitOfMeasure for a BitRate.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="bps">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Bit per second.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Gbps">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">GBit per second.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="kbps">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">kBit per second.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Mbps">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">MBit per second.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="UnitOfConditionValue">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A UnitOfMeasure for a condition value.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Millisecond">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A millisecond.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Minute">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A minute.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Percent">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Percent.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Pixel">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pixel.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Second">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A second.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="UnitOfExtent">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A UnitOfMeasure for an Extent.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="cm">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Centimeter.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Inch">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Inch.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="mm">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Millimeter.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PercentOfScreen">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Percent of the screen.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Pixel">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Pixel.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="UnitOfFrameRate">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A UnitOfMeasure for a FrameRate.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Hz(interlaced)">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hertz, interlaced.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Hz(non-interlaced)">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hertz, non-interlaced.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="UnitOfFrequency">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A UnitOfMeasure for a frequency.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="GHz">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">GHertz.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Hz">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Hertz.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="kHz">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">kHertz.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MHz">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">MHertz.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="UpdateIndicator">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Message according to whether the Message contains original data or updates to previously sent data.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="OriginalMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message which contains data that has not previously been communicated to the MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UpdateMessage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Message which contains data that updates data previously communicated to the MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="UseType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of a nature of a Service, or a Release, as used by a Consumer.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AsPerContract">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a MessageSender wishes to indicate that the value within the allowed value set is defined by the contractual relationship between MessageSender and MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Broadcast">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Deliver a Resource using radio waves on the radio frequency portion of the electromagnetic spectrum. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ConditionalDownload">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Download under a condition (e.g. tethered to a service or device).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ContentInfluencedStream">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Stream where the only interactivity provided allows the Consumer to start, stop, pause, fast forward and rewind the Stream, and where there is limited flexibility to influence the content of the Stream.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Display">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To display a Resource on a device where it will disappear when the device is switched off. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Download">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To transfer a Release from a Service's Computer to a Consumer's Computer for later consumption. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DubForAdvertisement">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To reproduce an audio Resource in the creation of the soundtrack of an audio or audiovisual Advertisement. Note: this use does not include the public performance of the included Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DubForLivePerformance">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To reproduce a Resource to enable a live Performance event. Note: this includes dramatic performances, dance shows and fashion exhibitions.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DubForMovies">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To reproduce an audio Resource in the creation of a soundtrack of an audiovisual Work. Note: this use does not include the public performance of the included Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DubForMusicOnHold">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To reproduce an audio Resource in the creation of a music on hold system. Note: this use does not include the public performance of the included Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DubForPublicPerformance">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To reproduce an audio Resource to enable a public Performance. Note: this use does not include the public performance of the included Resource. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DubForRadio">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To reproduce an audio Resource to enable any form of radio transmission. Note: this use does not include the public performance of the included Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="DubForTV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To reproduce an audio Resource to enable any form of television transmission. Note: this use does not include the public performance of the included Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ExtractForInternet">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To reproduce and make available an excerpt from a Resource in an on demand internet streaming service. This use applies for example to excerpts/previews of sound recordings that consumers can listen to on-demand on sites such as Amazon or iTunes before buying the previewed product.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KioskDownload">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Download directly from a Kiosk to a consumer device. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Narrowcast">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Deliver a Resource to a specific list of recipients, by terrestrial or satellite transmission. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonInteractiveStream">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Stream a Release as part of a scheduled program that has been a-priori arranged. Consumers cannot directly influence the content or order of a NonInteractiveStream. NonInteractiveStreams are often referred to as web casts or pre-programmed Streams.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OnDemandStream">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Stream a Release with full interactivity.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PerformAsMusicOnHold">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Perform a Resource in a music on hold service.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PerformInLivePerformance">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Perform a Resource as part of a live Performance event. Note: this includes dramatic performances, dance shows and fashion exhibitions.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PerformInPublic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Perform publicly. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PermanentDownload">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Download for permanent storage and subsequent consumption by the Consumer.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Playback">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To play a Resource in a Release as an analogue signal for listening and/or viewing by an individual or small group.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PlayInPublic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To play a Resource in a Release publicly. This UseType is typically used when reporting such usages to rights holders.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Podcast">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Deliver a series of Resources as a download via web syndication.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Print">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Copy a Resource on paper or an another permanent Medium where it can be seen. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PrivateCopy">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Copy a Resource for private use. This UseType is typically used when reporting revenues related to private copying levies.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PurchaseAsPhysicalProduct">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To purchase a PhysicalProduct.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Rent">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To allow access to a Release for a limited Period of Time.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Simulcast">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Stream simultaneously over two or more different media systems or channels. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Stream">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To stream a Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TetheredDownload">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Download to a tethered download host (a device which must be connected to a DSP's service through a broadband connection whenever a downloaded Resource is played).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TimeInfluencedStream">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Stream where the only interactivity provided allows the Consumer to start, stop, pause, fast forward and rewind the Stream.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UseAsAlertTone">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To use a Resource in a Release as an alert primarily on a MobileTelephone for an event other than an incoming phone call. Examples: an incoming text message or a new voice mail.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UseAsDevice">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Use a Resource in a Release that has been provided to a Consumer as part of a hardware purchase.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UseAsKaraoke">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The use of a Release for a form of entertainment in which an amateur singer or singers sing along with recorded music on microphone.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UseAsRingbackTone">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Use a Resource in a Release as the audible ringing that is heard primarily on a MobileTelephone by the calling party after dialing and prior to the call being answered at the receiving end.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UseAsRingbackTune">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Use a Resource in a Release as ringbacktune.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UseAsRingtone">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Use a Resource in a Release as an alert for an incoming phone call primarily on a MobileTelephone.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UseAsRingtune">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Use a Resource in a Release as ringtune. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UseAsScreensaver">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To use a Resource in a Release as a screen saver for an idling device.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UseAsVoiceMail">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Use a Resource as a voice greeting that contains an audio master clip in the background. Such a greeting can be used for outgoing and/or incoming voicemails.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UseAsWallpaper">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">[missing definition]</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UseForIdentification">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To use a Resource in a Release to aid identification processes (e.g. to support rights management operations where a record company provides sound recordings to a service provider for fingerprinting or watermarking). For the avoidance of doubt: this UseType does not include making the Release available to Consumers.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UseInMobilePhoneMessaging">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To reproduce and perform a Resource in a phone messaging system.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UseInPhoneListening">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To reproduce and perform a Resource in a service for phone based listening.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserMakeAvailableLabelProvided">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A UseType in which Consumers use a Release as part of their own Creation (e.g. a web site) only when the Release is provided by the ReleaseCreator to the service provider (e.g. the web site hosting company) and where the ReleaseCreator has stipulated to the service provider the ways in which the Release may be used by Consumers and these stipulations are conveyed to Consumers.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserMakeAvailableUserProvided">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A UseType in which Consumers use a Release as part of their own Creation (e.g. a web site) when the Release is not provided by the ReleaseCreator to the service provider (e.g. the web site hosting company) but by the Consumer or by other Consumers making the Release available through the service provider.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Webcast">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">To Deliver a Resource over the Internet using streaming technology. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="UserInterfaceType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of physical interface by which a Consumer uses a Service or Release.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AsPerContract">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a MessageSender wishes to indicate that the value within the allowed value set is defined by the contractual relationship between MessageSender and MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ConnectedDevice">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A device for interacting with Releases that is directly connected to the Internet. This includes set-top boxes.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="GameConsole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An interactive entertainment Computer or electronic device with the primary function to manipulate the video display signal of a display device (a television, monitor, etc.) to display a game.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Jukebox">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A device for playing back audio and/or audio-visual Resources in a defined public location on demand by an individual Consumer usually following payment.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="KaraokeMachine">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A device for Karaoke applications.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Kiosk">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A device in a fixed physical location for vending Resources chosen by an individual Consumer usually upon payment onto a physical Carrier.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LocalStorageJukebox">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Jukebox where the Releases are stored locally.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PersonalComputer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A small Computer based on a microprocessor. In addition to the microprocessor, a PersonalComputer has a keyboard for entering data, a monitor for displaying information, speakers for producing sound and a storage device for saving data. A PersonalComputer may be a desktop or laptop, and it may run a variety of OperatingSystems.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PhysicalMediaWriter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A device that can be used to transfer Resources to physical media such as CD-ROMs, DVDs or flash memory.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="PortableDevice">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A small, portable device with many of the features of a laptop PersonalComputer, which is also or primarily designed for storing, organizing and playing Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RemoteStorageJukebox">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Jukebox where the Releases are stored remotely and are accessed during play-back.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ValueType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of RoyaltyRate.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Calculated">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A value which is the calculated RoyaltyRate as agreed in the relevant contract.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Maximum">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A value which is the ceiling for the RoyaltyRate as agreed in the relevant contract.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Minimum">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A value which is the floor for the RoyaltyRate as agreed in the relevant contract.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="VideoCodecType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of VideoCodec.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AVC">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Advanced Video Coding as specified in ISO/IEC 14496-10.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="H.261">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A VideoCodec as specified in ITU-T H.261.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="H.263">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A VideoCodec as specified in ITU-T H.263.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MPEG-1">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A VideoCodec defined by the Moving Pictures Expert Group and specified in ISO/IEC 11172-2.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MPEG-2">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A VideoCodec defined by the Moving Pictures Expert Group and specified in ISO/IEC 13818-2.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MPEG-4">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A VideoCodec defined by the Moving Pictures Expert Group and specified in ISO/IEC 14469-2.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="QuickTime">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">QuickTime as developed by Apple Inc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="RealVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Real Video as developed by RealNetworks Inc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Shockwave">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Shockwave as developed by Macromedia Inc.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="WMV">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Windows Media Video as developed by Microsoft Corp.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="VideoContentType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Video.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="ActedVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video that is acted (not an Animation).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Animation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording using a rapid display of a sequence of images of 2-D or 3-D artwork or model positions in order to create an illusion of movement.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="AnimationAndActedVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video that is both acted and an Animation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="VideoDefinitionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of resolution (or definition) in which a Video is provided.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="HighDefinition">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A VideoDefinitionType of a Video that is provided in a resolution exceeding 704 x 480 pixels.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="StandardDefinition">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A VideoDefinitionType of a Video that is provided in a resolution not exceeding 704 x 480 pixels.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="VideoType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of Video.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="AdvertisementVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video created for specifically to promote another Video, embodying a MusicalWork. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Animation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording using a rapid display of a sequence of images of 2-D or 3-D artwork or model positions in order to create an illusion of movement.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="BehindTheScenes">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording documenting events happening behind the scenes.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ConcertClip">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An extract of a ConcertVideo.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ConcertVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video recording of a live Performance, usually of music, before an audience. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="CorporateFilm">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording made for use within a corporate entity. Examples include company-internal training videos.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Documentary">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording that presents a social, political, scientific or historical subject. Documentaries include current affairs programmes, TV magazines, biographies and 'making of' programs.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Episode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Part of a Series made available at a specific point in time. It may be that a Season or Series is not yet complete when an Episode is made available. Episodes include 'pilots'.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="FeatureFilm">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording made for initial distribution in cinemas, where it would be the 'main attraction' of the screening, or prime-time television.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="InfomercialVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video created for specifically to promote another Video, embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Interview">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording of an interview.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Karaoke">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video for Karaoke applications, typically for singing along to.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LiveEventVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording capturing an Event such as a sporting event, theatrical performances, etc. This allowed value is deprecated. DDEX advises that this value will be removed at a future date and therefore recommends against using it.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LongFormMusicalWorkVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video of an extended duration typically containing multiple tracks embodying at least one MusicalWork. Example: a concert video. LongFormMusicalWorkVideos are typically identified by an ISRC.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LongFormNonMusicalWorkVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video of an extended duration not embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="LyricVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording (often a slide show), with captions showing the lyrics.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Menu">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An aid to navigate through a Video which may be organized, e.g., into chapters. Menus are typically used on a DVD-Video. </xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkClip">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An extract from a Video, embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkReadalongVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video to read along to, and interact with, stories and songs, embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkTrailer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video created for specifically to promote another Video, embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="MusicalWorkVideoChapter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A VideoChapter embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="News">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording, usually regularly scheduled, which reports current events.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonMusicalWorkClip">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An extract from a Video, not embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonMusicalWorkReadalongVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video to read along to, and interact with, stories and songs, not embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonMusicalWorkTrailer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video created for specifically to promote another Video, not embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonMusicalWorkVideoChapter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A VideoChapter not embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NonSerialAudioVisualRecording">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording that is not part of a Series or Season.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="OperaVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video recording of Performance of an opera.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Season">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Set of Episodes. Typically, a Season contains all Episodes to be made available in a pre-determined time frame, which often is within a twelve-month period. It may be that a Series is not yet complete when an Season is made available.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Series">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Set of Resources (Episodes) designed to be made available sequentially.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ShortFormMusicalWorkVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video whose audio content corresponds exactly or approximately to that of an audio-only Single which embodies at least one MusicalWork. ShortFormMusicalWorkVideos are typically identified by an ISRC.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ShortFormNonMusicalWorkVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video of a short ended duration not embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="SpecialEvent">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An audio-visual Recording made for a special event.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TheatricalWorkVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video recording of Performance of a theatrical work.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TrailerVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video created for specifically to promote another Video, embodying a MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="TvShowVideo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Video recording of a TV show.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Unknown">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity used when a sender of a DdexMessage wishes to indicate that the value within the allowed value set is unknown.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VideoChapter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A section of a Video defined by a start and end point. Typical VideoChapters are MusicalWorkVideoChapter or NonMusicalWorkVideoChapter.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="VideoStem">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An unedited audio-visual Recording that was recorded as part of a session to produce, for instance, a ShortFormMusicVideo, but that has not been incorporated into the final version.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="VisualPerceptionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of MusicalCreation according to how it is experienced in an audio-visual Creation.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Background">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Music which is dubbed in for effect. It is not heard by the actors or performers in an audio-visual Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Visual">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of a MusicalCreation that is visibly experienced by the characters in the containing Resource, Collection or Release (e.g. a character sings a song or actively listens to a song played on the radio).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="VocalType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Type of a MusicalCreation according to the occurrence of vocals.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="Instrumental">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of a MusicalCreation that contains only (musical) instruments.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="UserDefined">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of an Entity which is defined by a sender of a DdexMessage in a manner acceptable to its recipient.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="Vocal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of a MusicalCreation that contains (human) voice.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="WsMessageStatus">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Status of a WsMessage.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="BackendProcessingError">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Status indicating that the received WsMessage caused a backend processing error when evaluated or acted on.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="NoValidMessageReceived">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Status indicating that the received WsMessage was either not received successfully or is a not valid XML.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ValidMessageQueuedForProcessing">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Status indicating that the received WsMessage was received successfully, is a valid XML file and has been queued for processing.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="ValidMessageReceived">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Status indicating that the received WsMessage was received successfully and is a valid XML file.</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="TerritoryCode">
+     <xs:annotation>
+       <xs:documentation source="ddex:Definition">A code representing a Territory. This includes ISO 3166-1 two-letter codes plus a code for Worldwide (This list is included here for compatibility reasons. Current standards use other TerritoryCode lists).</xs:documentation>
+     </xs:annotation>
+     <xs:union memberTypes="avs:IsoTerritoryCode avs:DdexTerritoryCode"/>
+   </xs:simpleType>
+</xs:schema>

--- a/spec/examples/ddex-mlc/music-licensing-companies.xsd
+++ b/spec/examples/ddex-mlc/music-licensing-companies.xsd
@@ -1,0 +1,4078 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:mlc="http://ddex.net/xml/mlc/12"
+           xmlns:avs="http://ddex.net/xml/avs/avs"
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://ddex.net/xml/mlc/12"
+           elementFormDefault="unqualified"
+           attributeFormDefault="unqualified">
+   <xs:import namespace="http://www.w3.org/2000/09/xmldsig#"
+              schemaLocation="http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd"/>
+    <xs:import namespace="http://ddex.net/xml/avs/avs"
+               schemaLocation="avs.xsd"/>
+   <xs:annotation>
+      <xs:documentation>© 2006-2015 Digital Data Exchange, LLC (DDEX)</xs:documentation>
+      <xs:documentation>This XML Schema Definition file is, together with all DDEX standards, subject to two licences: If you wish to evaluate whether the standard meets your needs please have a look at the Evaluation Licence at https://kb.ddex.net/display/HBK/Evaluation+Licence+for+DDEX+Standards. If you want to implement and use this DDEX standard, please take out an Implementation Licence. For details please go to http://ddex.net/apply-ddex-implementation-licence.</xs:documentation>
+   </xs:annotation>
+   <xs:element name="DeclarationOfSoundRecordingRightsClaimMessage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Message in the Music Licensing Company Message Suite Standard containing details of a SoundRecording. </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element name="MessageHeader" type="mlc:MessageHeader">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The MessageHeader for the DeclarationOfSoundRecordingRightsClaimMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="MessageNotificationPeriod"
+                        minOccurs="0"
+                        type="mlc:MessageNotificationPeriod">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of a reporting Period covered by the Message. It must contain at least one out of StartDate or EndDate. The StartDate must be earlier than the EndDate if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="ResourceList" type="mlc:ResourceList">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of one or more Resources.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+         <xs:attribute name="MessageSchemaVersionId" type="xs:string" use="required">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the XML schema used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="BusinessProfileVersionId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the business profile used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="ReleaseProfileVersionId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the release profile used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Language and script for the Elements of the DeclarationOfSoundRecordingRightsClaimMessage as defined in IETF RfC 5646. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="RequestSoundRecordingInformationMessage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Message in the Music Licensing Company Message Suite Standard containing a request for a declaration of SoundRecordings. </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element name="MessageHeader" type="mlc:MessageHeader">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The MessageHeader for the RequestSoundRecordingInformationMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="MessageNotificationPeriod"
+                        minOccurs="0"
+                        type="mlc:MessageNotificationPeriod">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of a reporting Period covered by the Message. It must contain at least one out of StartDate or EndDate. The StartDate must be earlier than the EndDate if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="RequestedSoundRecording"
+                        minOccurs="0"
+                        maxOccurs="unbounded"
+                        type="mlc:RequestedSoundRecording">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of a requested SoundRecording.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+         <xs:attribute name="MessageSchemaVersionId" type="xs:string" use="required">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the XML schema used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="BusinessProfileVersionId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the business profile used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="ReleaseProfileVersionId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the release profile used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Language and script for the Elements of the RequestSoundRecordingInformationMessage as defined in IETF RfC 5646. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="RevokeSoundRecordingRightsClaimMessage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Message in the Music Licensing Company Message Suite Standard in which a claim, typically communicated via a DeclarationOfSoundRecordingRightsClaimMessage, is revoked. </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element name="MessageHeader" type="mlc:MessageHeader">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The MessageHeader for the RevokeSoundRecordingRightsClaimMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="MessageNotificationPeriod"
+                        minOccurs="0"
+                        type="mlc:MessageNotificationPeriod">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of a reporting Period covered by the Message. It must contain at least one out of StartDate or EndDate. The StartDate must be earlier than the EndDate if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="SoundRecordingId"
+                        minOccurs="0"
+                        maxOccurs="unbounded"
+                        type="mlc:SoundRecordingId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecordingId.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+         <xs:attribute name="MessageSchemaVersionId" type="xs:string" use="required">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the XML schema used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="BusinessProfileVersionId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the business profile used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="ReleaseProfileVersionId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the release profile used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Language and script for the Elements of the RevokeSoundRecordingRightsClaimMessage as defined in IETF RfC 5646. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="SalesReportMessage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Message in the Music Licensing Company Message Suite Standard used by one Music Licensing Company to inform a second Music Licensing Company about unit sales of Releases in electronic or physical formats.</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element name="MessageHeader" type="mlc:MessageHeader">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The MessageHeader for the SalesReportMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="SalesReport" maxOccurs="unbounded" type="mlc:SalesReport">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of SalesTransactions by a distribution partner reported to a record company.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="NumberOfSalesTransactionRecords" type="xs:integer">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The check number which identifies the number of SalesTransaction records contained in the SalesReportMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+         <xs:attribute name="MessageSchemaVersionId" type="xs:string" use="required">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the XML schema used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="BusinessProfileVersionId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the business profile used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="ReleaseProfileVersionId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the release profile used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Language and script for the Elements of the SalesReportMessage as defined in IETF RfC 5646. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="DeclarationOfRevenueMessage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Message in the Music Licensing Company Message Suite Standard containing a declaration of Revenue from the usage of Releases. </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element name="MessageHeader" type="mlc:MessageHeader">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The MessageHeader for the DeclarationOfRevenueMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="RevenueDeclaration"
+                        maxOccurs="unbounded"
+                        type="mlc:RevenueDeclaration">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of one or more Revenue declarations for a SoundRecording.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="NumberOfRevenueByUsageRecords" type="xs:integer">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The check number which identifies the number of RevenueByUsage records contained in the DeclarationOfRevenueMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+         <xs:attribute name="MessageSchemaVersionId" type="xs:string" use="required">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the XML schema used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="BusinessProfileVersionId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the business profile used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="ReleaseProfileVersionId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the release profile used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Language and script for the Elements of the DeclarationOfRevenueMessage as defined in IETF RfC 5646. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="ManifestMessage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Message in the Music Licensing Company Message Suite Standard that is sent to document the FTP transfer of a batch of Messages.</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element name="FtpMessageHeader" type="mlc:FtpMessageHeader">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The MessageHeader for the ManifestMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="IsTestFlag" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the Message is a TestMessage (=true) or a LiveMessage (=false).</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="RootDirectory" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">An Identifier of the root directory of all Messages in the batch communicated through the ManifestMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="NumberOfMessages" type="xs:integer">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The number of Messages in the batch communicated through the ManifestMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="MessageInBatch"
+                        maxOccurs="unbounded"
+                        type="mlc:MessageInBatch">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of a Message in the batch.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+         <xs:attribute name="BusinessProfileVersionId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the business profile used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="ReleaseProfileVersionId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the release profile used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:complexType name="DetailedArtist">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an Artist. An Artist may be described through Name, Identifier and Roles.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice>
+            <xs:element name="PartyId" maxOccurs="unbounded" type="mlc:PartyId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:sequence>
+               <xs:element name="PartyName" maxOccurs="unbounded" type="mlc:PartyName">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyName(s).</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+               <xs:element name="PartyId"
+                           minOccurs="0"
+                           maxOccurs="unbounded"
+                           type="mlc:PartyId">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+            </xs:sequence>
+         </xs:choice>
+         <xs:element name="InstrumentType"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of musical instrument played by the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ArtistDelegatedUsageRights"
+                     minOccurs="0"
+                     type="mlc:ArtistDelegatedUsageRights">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the kinds of usage for which rights have been delegated by the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Sex" minOccurs="0" type="avs:Sex">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The sex of the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Nationality"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:AllTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The nationality of the Artist. The use of ISO TerritoryCodes is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DateAndPlaceOfBirth" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of birth. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DateAndPlaceOfDeath" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of death. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PrimaryRole" minOccurs="0" type="mlc:ArtistRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the primary role played by the Artist in relation to other Artists.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Performance"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Performance">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of a Performance.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PrimaryInstrumentType" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of (musical) instrument primarily played by the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="GoverningAgreementType"
+                     minOccurs="0"
+                     type="mlc:GoverningAgreementType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of an agreement that covers the Artist's participation in making a SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ContactInformation" minOccurs="0" type="mlc:ContactId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of contact Identifiers of the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TerritoryOfResidency"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:AllTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The country of main residency of the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalRoles"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ArtistRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the additional roles played by the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Genre"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Genre">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a typical or main Genre relating to the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Membership"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Membership">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a membership in a collective rights management organization.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="SequenceNumber" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The number indicating the order of the Artist in a group of Artists. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="HostSoundCarrier">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a HostSoundCarrier of a SoundRecording. This Composite exists to support the identification and matching of SoundRecording information.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ReleaseId"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ReleaseId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of ReleaseIds of the HostSoundCarrier. If available, a GRid has to be used. If the HostSoundCarrier contains only one SoundRecording, the ISRC of the SoundRecording may be used instead.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RightsAgreementId" minOccurs="0" type="mlc:RightsAgreementId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of Identifiers of a License, Claim, RightShare or contract for the MusicalWork(s) used in the HostSoundCarrier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Title"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Title">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the HostSoundCarrier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtist"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Artist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the DisplayArtist for the HostSoundCarrier. The DisplayArtist may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdministratingRecordCompany"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:AdministratingRecordCompany">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the AdministratingRecordCompany for the Rights in the HostSoundCarrier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TrackNumber" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The TrackNumber of the SoundRecording within the HostSoundCarrier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VolumeNumberInSet" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The SequenceNumber within the Set of the volume containing the SoundRecording, where the HostSoundCarrier is a Set (such as a 'box set' of CDs).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SideNumber" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The SideNumber of the SoundRecording within the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CarrierType" minOccurs="0" type="mlc:CarrierType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the HostSoundCarrier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LabelName"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:LabelName">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name of the Label for the Release. The use of multiple LabelNames is discouraged unless used to communicate label names in different languages and/or scripts.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfSoundRecordingsClaimedInCarrier" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of SoundRecordings that are claimed.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfDisks" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of disks comprised by the HostSoundCarrier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CompilationType" minOccurs="0" type="avs:CompilationType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of Compilation.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseType" minOccurs="0" type="mlc:ReleaseType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the form in which a ReleaseCreator anticipates offering the Release to Consumers.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsPhysicalDistribution" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the HostSoundCarrier is physical or digital/electronic (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLine" minOccurs="0" type="mlc:PLine">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PLine for the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLine" minOccurs="0" type="mlc:CLine">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CLine for the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseDate" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Release is made available for Usage. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleasingCompany" minOccurs="0" type="mlc:PartyDescriptor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the company that is releasing the HostSoundCarrier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DistributingCompany" minOccurs="0" type="mlc:PartyDescriptor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the company that is distributing the HostSoundCarrier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CdProtectionType" minOccurs="0" type="mlc:CdProtectionType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a CdProtectionType.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RecordingMode" minOccurs="0" type="avs:RecordingMode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A RecordingMode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DigitizationMode" minOccurs="0" type="avs:DigitizationMode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DigitizationMode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsHiddenResource" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is hidden in some way from the Consumer (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsBonusResource" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is additional to those on the original Release of which this is a Version (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsInternalCompilation" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the HostSoundCarrier is a compilation where all tracks are owned by the issuing record company (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="MessageInBatch">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Music Licensing Company Message in a Batch.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="MessageType" type="avs:MlcMessageType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Type of Message.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Identifier of the Message.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="URL" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A URL of the Message.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Producer">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Producer. A Producer may be described through Name and Identifier.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice>
+            <xs:element name="PartyId" maxOccurs="unbounded" type="mlc:PartyId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:sequence>
+               <xs:element name="PartyName" maxOccurs="unbounded" type="mlc:PartyName">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyName(s).</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+               <xs:element name="PartyId"
+                           minOccurs="0"
+                           maxOccurs="unbounded"
+                           type="mlc:PartyId">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+            </xs:sequence>
+         </xs:choice>
+         <xs:element name="TerritoryCode"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:AllTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Territory of the Producer. The use of ISO TerritoryCodes (or the term 'Worldwide”) is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ReportedUsage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more Usages for a Resource.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="RecipientRevenueType" type="avs:RecipientRevenueType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of Revenue according to the recipient of the payment.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RevenueSourceType" type="avs:RevenueSourceType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of Revenue earned by the SoundRecording, according to the way the Revenue is generated.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="UsagePeriod" type="mlc:Period">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details about the Period of Time for which a usage is reported.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RevenueByUsage"
+                     maxOccurs="unbounded"
+                     type="mlc:RevenueByUsage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Revenue specified for a UseType.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="RequestedSoundRecording">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a requested SoundRecording.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="SoundRecordingId" minOccurs="0" type="mlc:SoundRecordingId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecordingId.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReferenceTitle" minOccurs="0" type="mlc:ReferenceTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the ReferenceTitle of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceContributor"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:PartyDescriptor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Contributor to the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ResourceContributor">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the Name, Identifier and role(s) of a Contributor to a Resource.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice>
+            <xs:element name="PartyId" maxOccurs="unbounded" type="mlc:PartyId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:sequence>
+               <xs:element name="PartyName" maxOccurs="unbounded" type="mlc:PartyName">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyName(s).</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+               <xs:element name="PartyId"
+                           minOccurs="0"
+                           maxOccurs="unbounded"
+                           type="mlc:PartyId">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+            </xs:sequence>
+         </xs:choice>
+         <xs:element name="ResourceContributorRole"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ResourceContributorRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a role played by the Contributor.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsFeaturedArtist" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the Contributor is a featured Artist (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsContractedArtist" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the Contributor is an Artist that has a contract for its part in creating the Resource (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="InstrumentType"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of musical instrument played by the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ArtistDelegatedUsageRights"
+                     minOccurs="0"
+                     type="mlc:ArtistDelegatedUsageRights">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the kinds of usage for which rights have been delegated by the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Sex" minOccurs="0" type="avs:Sex">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The sex of the Contributor.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Nationality"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ddexC_CurrentTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The nationality of the Contributor.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DateAndPlaceOfBirth" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of birth. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DateAndPlaceOfDeath" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of death. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PrimaryRole" minOccurs="0" type="mlc:ArtistRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the primary role played by the Artist in relation to other Artists.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Performance"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Performance">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of a Performance.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PrimaryInstrumentType" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of (musical) instrument primarily played by the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="GoverningAgreementType"
+                     minOccurs="0"
+                     type="mlc:GoverningAgreementType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of an agreement that covers the Artist's participation in making a SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ContactInformation" minOccurs="0" type="mlc:ContactId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of contact Identifiers of the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TerritoryOfResidency"
+                     minOccurs="0"
+                     type="mlc:AllTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The country of main residency of the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Citizenship" minOccurs="0" type="mlc:CurrentTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The country of whose citizenship the Artist has.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalRoles"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ArtistRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the additional roles played by the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Genre"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Genre">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a typical or main Genre relating to the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Membership"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Membership">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a membership in a collective rights management organization.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="CharacterType" minOccurs="0" type="avs:CharacterType">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Type of the Character.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="Character" minOccurs="0" type="mlc:PartyName">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the Name of the role played by a Contributor.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="SequenceNumber" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The number indicating the order of the ResourceContributor in a group of ResourceContributors that have contributed to a Resource. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="ResourceList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more Resources. ResourceList provides a simple means of aggregating Resources without any explicit sequencing or grouping: if that is needed it is provided by the ResourceGroup Composite. </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="SoundRecording"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:SoundRecording">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Video"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Video">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Revenue">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Revenue.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="GrossRevenue" type="xs:decimal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Revenue without or before deductions.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdminFee" type="xs:decimal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An administrative fee to be paid.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NetRevenueBeforeWithholdingTax" type="xs:decimal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Revenue without or before taking the WithholdingTax into account.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="WithholdingTax" type="xs:decimal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">[missing definition]</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NetRevenue" type="xs:decimal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Revenue after deductions.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="RevenueByTerritory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Revenue specified for a Territory.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TerritoryCode" type="mlc:AllTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Territory for which Revenue is reported. The use of ISO TerritoryCodes (or the term 'Worldwide”) is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="UserName" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Identifier of a user.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="UserRole" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description providing information about the role the user of the SoundRecording. This Comment is used to further detail the UserName.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DurationUsed"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Duration of the SoundRecording that has been used in a specified context (using the ISO 8601:2004 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfUsages"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A number of times a SoundRecording has been used.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsCredit" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Revenue is a credit (=true) or a debit (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Revenue" type="mlc:Revenue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Revenue.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="RevenueByUsage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Revenue specified for a UseType.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="UseType" type="mlc:UseType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a nature of a usage.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RevenueByTerritory"
+                     maxOccurs="unbounded"
+                     type="mlc:RevenueByTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Revenue specified for a Territory.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="RevenueDeclaration">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more Revenue declarations.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="SoundRecordingId" type="mlc:SoundRecordingId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecordingId of the SoundRecording for which Revenue is declared.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReferenceTitle" type="mlc:ReferenceTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the ReferenceTitle of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtist" maxOccurs="unbounded" type="mlc:Artist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the DisplayArtist for the SoundRecording. The DisplayArtist may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CurrencyOfAccounting" type="avs:CurrencyCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Currency in which the Revenues are accounted (represented by an ISO 4217 CurrencyCode).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReportedUsage" maxOccurs="unbounded" type="mlc:ReportedUsage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of one or more Usages for the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="RightsController">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a RightsController. RightsControllers are typicallydescribed by Name, Identifier and role(s).</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice>
+            <xs:element name="PartyId" maxOccurs="unbounded" type="mlc:PartyId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:sequence>
+               <xs:element name="PartyName" maxOccurs="unbounded" type="mlc:PartyName">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyName(s).</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+               <xs:element name="PartyId"
+                           minOccurs="0"
+                           maxOccurs="unbounded"
+                           type="mlc:PartyId">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+            </xs:sequence>
+         </xs:choice>
+         <xs:element name="RightsControllerRole"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="avs:RightsControllerRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A role that describes the Party involved in the administration of Rights.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="RightShareUnknown" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the RightSharePercentage is unknown (=true) or not (=false).</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="RightSharePercentage" type="mlc:Percentage">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The share of the licensed Rights owned by the RightsController. RightShare information is given as a xs:decimal value with up to 6 digits (e.g. '12.5' represents 12.5%). If no information is given, 100% is assumed.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="RightsControllerType"
+                     minOccurs="0"
+                     type="avs:RightsControllerType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A type of the RightsController.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DelegatedUsageRights"
+                     maxOccurs="unbounded"
+                     type="mlc:DelegatedUsageRights">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the kinds of usage for which rights have been delegated.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsPayingOutRoyalties" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the RightsController is paying out royalties for all other relevant RightsControllers (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="SequenceNumber" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The number indicating the order of the RightsController in a group of RightsControllers. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="SalesReport">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of SalesTransactions.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TerritoryCode"
+                     maxOccurs="unbounded"
+                     type="mlc:CurrentTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Territory for which SalesTransactions are reported. The use of ISO TerritoryCodes (or the term 'Worldwide”) is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageNotificationPeriod" type="mlc:MessageNotificationPeriod">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the reporting Period covered by the SalesReportMessage.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SalesTransaction"
+                     maxOccurs="unbounded"
+                     type="mlc:SalesTransaction">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a SalesTransaction for specified Usages of the Release or Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="SalesTransaction">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SalesTransaction.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ReleaseId" type="mlc:ReleaseId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of ReleaseIds of the Release. If available, a GRid has to be used. If the Release contains only one SoundRecording, the ISRC of the SoundRecording may be used instead.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Label" minOccurs="0" type="mlc:PartyDescriptor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the label on which the Release was marketed.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsCompilation" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the Release is a compilation (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfSoundRecordingsClaimedInCarrier"
+                     minOccurs="0"
+                     type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of SoundRecordings that are claimed.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfUnitsSold" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of unit sales of the Release. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="SampledSoundRecording">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecording.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="SoundRecordingId"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:SoundRecordingId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecordingId.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Title"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Title">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="SoundRecording">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecording.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="SoundRecordingType"
+                     minOccurs="0"
+                     type="mlc:SoundRecordingType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Type of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsArtistRelated" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is related to an Artist (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SoundRecordingId"
+                     maxOccurs="unbounded"
+                     type="mlc:SoundRecordingId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecordingId.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IndirectSoundRecordingId"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:MusicalWorkId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a MusicalWorkId of a MusicalWork used in the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the SoundRecording within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ReferenceTitle" type="mlc:ReferenceTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the ReferenceTitle of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="InstrumentationDescription"
+                     minOccurs="0"
+                     type="mlc:Description">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a Description of the Type of instrumentation of the MusicalWork(s) in the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsMedley" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is a Medley (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsPotpourri" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is a Potpourri (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsInstrumental" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is instrumental (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsBackground" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is used as background to other audio or audiovisual material (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsHiddenResource" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is hidden in some way from the Consumer (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsBonusResource" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is additional to those on the original Release of which this is a Version (=true) or not (=false). This element is deprecated. DDEX advises that it may be removed at a future date and therefore recommends against using it. The IsBonusResource element in ResourceGroupContentItem should be used instead.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsComputerGenerated" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is generated by a computer (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NoSilenceBefore" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is preceded by a period of silence (=false) or not (=true). </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NoSilenceAfter" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is followed by a period of silence (=false) or not (=true). </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ContainsSamples" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording contains samples (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SampledSoundRecording"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:SampledSoundRecording">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a sampled SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PerformerInformationRequired" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether performer information is required (=true) or not (=false) when communicating details of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LanguageOfPerformance"
+                     minOccurs="0"
+                     type="avs:IsoLanguageCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Language of the Performance recorded in the SoundRecording (represented by an ISO 639-2 LanguageCode).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Duration" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Duration of the SoundRecording (using the ISO 8601:2004 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RightsAgreementId" minOccurs="0" type="mlc:RightsAgreementId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of Identifiers of a License, Claim, RightShare or contract for the MusicalWork(s) used in the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SoundRecordingCollectionReferenceList"
+                     minOccurs="0"
+                     type="mlc:SoundRecordingCollectionReferenceList">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of one or more Collections. The referenced Collection has to be of CollectionType AudioChapter. (Note: this Composite is not required for communication to Music Licensing Companies but is included in this Message to maintain compatibility to the Release Notification Message Suite Standard.)</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceMusicalWorkReferenceList"
+                     minOccurs="0"
+                     type="mlc:ResourceMusicalWorkReferenceList">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of one or more MusicalWorks contained in the SoundRecording. (Note: this Composite is not required for communication to Music Licensing Companies but is included in this Message to maintain compatibility to the Release Notification Message Suite Standard.)</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceContainedResourceReferenceList"
+                     minOccurs="0"
+                     type="mlc:ResourceContainedResourceReferenceList">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current SoundRecording. (Note: this Composite is not required for communication to Music Licensing Companies but is included in this Message to maintain compatibility to the Release Notification Message Suite Standard.)</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CreationDate" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SoundRecording was created. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MasteredDate" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SoundRecording was originally mastered (in either analogue or digital form). This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RemasteredDate" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SoundRecording was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SoundRecordingDetailsByTerritory"
+                     maxOccurs="unbounded"
+                     type="mlc:SoundRecordingDetailsByTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of Descriptors and other attributes of the SoundRecording which may vary according to Territory.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsUpdated" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording Element was updated (=true) or not (=false). When this Boolean Flag is set to true, the MessageRecipient is expected to replace any previously provided SoundRecording data with the now provided data. This attribute is deprecated. DDEX advises that it may be removed at a future date and therefore recommends against using it.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the SoundRecording as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="SoundRecordingDetailsByTerritory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of Descriptors and other attributes of a SoundRecording which may vary according to Territory of release.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice>
+            <xs:element name="TerritoryCode"
+                        maxOccurs="unbounded"
+                        type="mlc:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the SoundRecording details apply. Either this Element or ExcludedTerritory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide”) is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="ExcludedTerritoryCode"
+                        maxOccurs="unbounded"
+                        type="mlc:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the SoundRecording details do not apply. Either this Element or Territory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide”) is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="Title"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Title">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtist"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Artist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a DisplayArtist for the SoundRecording. A DisplayArtist may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayConductor"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:DetailedArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a DisplayConductor for the SoundRecording. A DisplayConductor may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayComposer"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:DetailedArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a DisplayComposer for the SoundRecording. A DisplayComposer may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FeaturedArtist"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:DetailedArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a FeaturedArtist for the SoundRecording. A FeaturedArtist may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FeaturedNonContractedArtist"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:DetailedArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a non-contracted FeaturedArtist for the SoundRecording. A non-contracted FeaturedArtist may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NonFeaturedArtist"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:DetailedArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a NonFeaturedArtist for the SoundRecording. A NonFeaturedArtist may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="InitialProducer"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Producer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an initial Producer for the SoundRecording. An initial Producer may be described through Name and Identifier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceContributor"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ResourceContributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Contributor to the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IndirectResourceContributor"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:IndirectResourceContributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an indirect Contributor to the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RightsAgreementId" minOccurs="0" type="mlc:RightsAgreementId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of Identifiers of a License, Claim, RightShare or contract for the MusicalWork(s) used in the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LabelName"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:LabelName">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name of the Label under which the Release is to be marketed. The use of multiple LabelNames is discouraged unless used to communicate label names in different languages and/or scripts.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RightsController"
+                     maxOccurs="unbounded"
+                     type="mlc:RightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RemasteredDate" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SoundRecording was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceReleaseDate" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SoundRecording was published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="OriginalResourceReleaseDate"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SoundRecording was originally published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]]. If one OriginalResourceReleaseDate is specified, the TerritoryCode attribute is not mandatory, but if more than one OriginalResourceReleaseDate is provided, all of these need to have a TerritoryCode attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLine"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:PLine">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PLine for the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Licensor" minOccurs="0" type="mlc:PartyDescriptor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Party granting the permission for Usage.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CourtesyLine" minOccurs="0" type="mlc:CourtesyLine">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SequenceNumber" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number indicating the order of the SoundRecording in a group of SoundRecordings in a Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="HostSoundCarrier"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:HostSoundCarrier">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a HostSoundCarrier on which the SoundRecording appears (e.g., the CD on which it was originally released). This Composite exists in the Release Notification Message Suite Standard, to support the identification and matching of SoundRecording information.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MarketingComment" minOccurs="0" type="mlc:Comment">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a Comment about the promotion and marketing of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Genre"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Genre">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Genre to which the SoundRecording belongs.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ParentalWarningType"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ParentalWarningType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the classification of the SoundRecording according to advice which it carries about the level of explicitness or offensiveness of its content.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AvRating"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:AvRating">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a rating for the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TechnicalSoundRecordingDetails"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:TechnicalSoundRecordingDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing technical details of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FulfillmentDate" minOccurs="0" type="mlc:FulfillmentDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a FulfillmentDate.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Keywords"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Keywords">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Description of the SoundRecording containing Keywords.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Synopsis" minOccurs="0" type="mlc:Synopsis">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Synopsis of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="GoverningAgreementType"
+                     minOccurs="0"
+                     type="mlc:GoverningAgreementType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of an agreement that covers the making of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfFeaturedArtists" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of FeaturedArtists associated with the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfFeaturedNonContractedArtists"
+                     minOccurs="0"
+                     type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of FeaturedArtists associated with the SoundRecording that are also NonContractedArtists.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfNonFeaturedArtists" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of NonFeaturedArtists associated with the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LineUpComplete" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the line up is complete (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfMainCharacters" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of MainCharacters associated with the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MainCharacterLineUpComplete" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the line up of MainCharacters is complete (=true) or not (=false). If no value is provided, no information about completeness is available.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfSupportingCharacters" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of SupportingCharacters associated with the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SupportingCharacterLineUpComplete"
+                     minOccurs="0"
+                     type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the line up of SupportingCharacters is complete (=true) or not (=false). If no value is provided, no information about completeness is available.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfOtherCharacters" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of OtherCharacters associated with the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="OtherCharacterLineUpComplete" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the line up of OtherCharacters is complete (=true) or not (=false). If no value is provided, no information about completeness is available.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the SoundRecordingDetailsByTerritory as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="TechnicalSoundRecordingDetails">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing technical details of a SoundRecording.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ContainerFormat" minOccurs="0" type="mlc:ContainerFormat">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ContainerFormat.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AudioCodecType" minOccurs="0" type="mlc:AudioCodecType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of AudioCodec.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the TechnicalSoundRecordingDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="TechnicalVideoDetails">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing technical details of a Video.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ContainerFormat" minOccurs="0" type="mlc:ContainerFormat">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ContainerFormat.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VideoCodecType" minOccurs="0" type="mlc:VideoCodecType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of VideoCodec.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the TechnicalSoundRecordingDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="Video">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Video.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="VideoType" minOccurs="0" type="mlc:VideoType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Type of the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsArtistRelated" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is related to an Artist (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VideoId" maxOccurs="unbounded" type="mlc:VideoId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a VideoId.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IndirectVideoId"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:MusicalWorkId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a MusicalWorkId of a MusicalWork used in the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the Video within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ReferenceTitle" type="mlc:ReferenceTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the ReferenceTitle of the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="InstrumentationDescription"
+                     minOccurs="0"
+                     type="mlc:Description">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a Description of the Type of instrumentation of the MusicalWork(s) in the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsMedley" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is a Medley (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsPotpourri" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is a Potpourri (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsInstrumental" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is instrumental (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsBackground" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is used as background to other audio or audiovisual material (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsHiddenResource" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is hidden in some way from the Consumer (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsBonusResource" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is additional to those on the original Release of which this is a Version (=true) or not (=false). This element is deprecated. DDEX advises that it may be removed at a future date and therefore recommends against using it. The IsBonusResource element in ResourceGroupContentItem should be used instead.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsComputerGenerated" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is generated by a computer (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NoSilenceBefore" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is preceded by a period of silence (=false) or not (=true). </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NoSilenceAfter" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is followed by a period of silence (=false) or not (=true). </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PerformerInformationRequired" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether performer information is required (=true) or not (=false) when communicating details of the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LanguageOfPerformance"
+                     minOccurs="0"
+                     type="avs:IsoLanguageCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Language of the Performance recorded in the Video (represented by an ISO 639-2 LanguageCode).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Duration" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Duration of the Video (using the ISO 8601:2004 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RightsAgreementId" minOccurs="0" type="mlc:RightsAgreementId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of Identifiers of a License, Claim, RightShare or contract for the MusicalWork(s) used in the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VideoCollectionReferenceList"
+                     minOccurs="0"
+                     type="mlc:SoundRecordingCollectionReferenceList">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of one or more Collections. The referenced Collection has to be of CollectionType VideoChapter.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceMusicalWorkReferenceList"
+                     minOccurs="0"
+                     type="mlc:ResourceMusicalWorkReferenceList">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of one or more MusicalWorks contained in the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceContainedResourceReferenceList"
+                     minOccurs="0"
+                     type="mlc:ResourceContainedResourceReferenceList">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CreationDate"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Video was created. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MasteredDate" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Video was originally mastered (in either analogue or digital form). This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RemasteredDate" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Video was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VideoDetailsByTerritory"
+                     maxOccurs="unbounded"
+                     type="mlc:VideoDetailsByTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of Descriptors and other attributes of the Video which may vary according to Territory.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsUpdated" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether the Video Element was updated (=true) or not (=false). When this Boolean Flag is set to true, the MessageRecipient is expected to replace any previously provided Video data with the now provided data. This attribute is deprecated. DDEX advises that it may be removed at a future date and therefore recommends against using it.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Video as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="VideoDetailsByTerritory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of Descriptors and other attributes of a Video which may vary according to Territory of release.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice>
+            <xs:element name="TerritoryCode"
+                        maxOccurs="unbounded"
+                        type="mlc:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the SoundRecording details apply. Either this Element or ExcludedTerritory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide”) is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="ExcludedTerritoryCode"
+                        maxOccurs="unbounded"
+                        type="mlc:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the SoundRecording details do not apply. Either this Element or Territory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide”) is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="Title"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Title">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtist"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Artist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a DisplayArtist for the SoundRecording. A DisplayArtist may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayConductor"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:DetailedArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a DisplayConductor for the SoundRecording. A DisplayConductor may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayComposer"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:DetailedArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a DisplayComposer for the SoundRecording. A DisplayComposer may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FeaturedArtist"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:DetailedArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a FeaturedArtist for the SoundRecording. A FeaturedArtist may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FeaturedNonContractedArtist"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:DetailedArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a non-contracted FeaturedArtist for the SoundRecording. A non-contracted FeaturedArtist may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NonFeaturedArtist"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:DetailedArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a NonFeaturedArtist for the SoundRecording. A NonFeaturedArtist may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="InitialProducer"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Producer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an initial Producer for the SoundRecording. An initial Producer may be described through Name and Identifier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceContributor"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ResourceContributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Contributor to the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IndirectResourceContributor"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:IndirectResourceContributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an indirect Contributor to the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RightsAgreementId" minOccurs="0" type="mlc:RightsAgreementId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of Identifiers of a License, Claim, RightShare or contract for the MusicalWork(s) used in the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LabelName"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:LabelName">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name of the Label under which the Release is to be marketed. The use of multiple LabelNames is discouraged unless used to communicate label names in different languages and/or scripts.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RightsController"
+                     maxOccurs="unbounded"
+                     type="mlc:RightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RemasteredDate" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SoundRecording was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceReleaseDate" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SoundRecording was published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="OriginalResourceReleaseDate"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SoundRecording was originally published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]]. If one OriginalResourceReleaseDate is specified, the TerritoryCode attribute is not mandatory, but if more than one OriginalResourceReleaseDate is provided, all of these need to have a TerritoryCode attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLine"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:PLine">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PLine for the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Licensor" minOccurs="0" type="mlc:PartyDescriptor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Party granting the permission for Usage.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CourtesyLine" minOccurs="0" type="mlc:CourtesyLine">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SequenceNumber" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number indicating the order of the SoundRecording in a group of SoundRecordings in a Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="HostSoundCarrier"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:HostSoundCarrier">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a HostSoundCarrier on which the SoundRecording appears (e.g., the CD on which it was originally released). This Composite exists in the Release Notification Message Suite Standard, to support the identification and matching of SoundRecording information.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MarketingComment" minOccurs="0" type="mlc:Comment">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a Comment about the promotion and marketing of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Genre"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Genre">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Genre to which the SoundRecording belongs.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ParentalWarningType"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ParentalWarningType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the classification of the SoundRecording according to advice which it carries about the level of explicitness or offensiveness of its content.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AvRating"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:AvRating">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a rating for the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TechnicalVideoDetails"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:TechnicalVideoDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing technical details of the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FulfillmentDate" minOccurs="0" type="mlc:FulfillmentDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a FulfillmentDate.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Keywords"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Keywords">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Description of the SoundRecording containing Keywords.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Synopsis" minOccurs="0" type="mlc:Synopsis">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Synopsis of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="GoverningAgreementType"
+                     minOccurs="0"
+                     type="mlc:GoverningAgreementType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of an agreement that covers the making of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfFeaturedArtists" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of FeaturedArtists associated with the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfFeaturedNonContractedArtists"
+                     minOccurs="0"
+                     type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of FeaturedArtists associated with the SoundRecording that are also NonContractedArtists.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfNonFeaturedArtists" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of NonFeaturedArtists associated with the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LineUpComplete" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the line up is complete (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfMainCharacters" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of MainCharacters associated with the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MainCharacterLineUpComplete" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the line up of MainCharacters is complete (=true) or not (=false). If no value is provided, no information about completeness is available.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfSupportingCharacters" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of SupportingCharacters associated with the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SupportingCharacterLineUpComplete"
+                     minOccurs="0"
+                     type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the line up of SupportingCharacters is complete (=true) or not (=false). If no value is provided, no information about completeness is available.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfOtherCharacters" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of OtherCharacters associated with the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="OtherCharacterLineUpComplete" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the line up of OtherCharacters is complete (=true) or not (=false). If no value is provided, no information about completeness is available.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the SoundRecordingDetailsByTerritory as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="AdministratingRecordCompany">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an AdministratingRecordCompany.</xs:documentation>
+      </xs:annotation>
+      <xs:choice>
+         <xs:element name="PartyId" maxOccurs="unbounded" type="mlc:PartyId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:sequence>
+            <xs:element name="PartyName" maxOccurs="unbounded" type="mlc:PartyName">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyName(s).</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="PartyId"
+                        minOccurs="0"
+                        maxOccurs="unbounded"
+                        type="mlc:PartyId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="Namespace" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Namespace of the Role if it belongs to a proprietary scheme. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UserDefinedValue" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A UserDefined value of the Role. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Role"
+                    type="avs:AdministratingRecordCompanyRole"
+                    use="required">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The role played by the Party responsible for administering Rights in a Resource or a Release.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="AllTerritoryCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a TerritoryCode.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:AllTerritoryCode">
+            <xs:attribute name="IdentifierType"
+                          type="avs:TerritoryCodeTypeIncludingDeprecatedCodes">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A standard used for the TerritoryCode. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the code is a TerritoryCode in accordance with ISO 3166-1 Alpha 2 standard (or Worldwide).</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Artist">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an Artist. An Artist may be described through Name, Identifier and Roles.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice>
+            <xs:element name="PartyId" maxOccurs="unbounded" type="mlc:PartyId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:sequence>
+               <xs:element name="PartyName" maxOccurs="unbounded" type="mlc:PartyName">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyName(s).</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+               <xs:element name="PartyId"
+                           minOccurs="0"
+                           maxOccurs="unbounded"
+                           type="mlc:PartyId">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+            </xs:sequence>
+         </xs:choice>
+         <xs:element name="ArtistRole" maxOccurs="unbounded" type="mlc:ArtistRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a role played by the Artist in relation to other Artists.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Nationality"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ddexC_CurrentTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The nationality of the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="SequenceNumber" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The number indicating the order of the Artist in a group of Artists. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="ArtistDelegatedUsageRights">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the kinds of usage for which rights have been delegated by an Artist.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="UseType" maxOccurs="unbounded" type="mlc:UseType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the use for which rights are delegated.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="UserInterfaceType"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:UserInterfaceType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a physical interface by which a Consumer uses a Service or Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PeriodOfRightsDelegation" type="mlc:Period">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details about a Period of Time for which the delegation of usage rights applies. Periods are typically described by at least a StartDate or EndDate.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TerritoryOfRightsDelegation"
+                     maxOccurs="unbounded"
+                     type="mlc:CurrentTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Territory for which the delegation of usage rights applies.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MembershipType" type="avs:MembershipType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of membership of the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ArtistRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an ArtistRole. Note: This can be used in a DdexMessage in relation to any Performance or Fixation either of which may form the whole or part of the Resource itself. Example: if an 'AssociatedPerformer' is shown as a Contributor to a MusicalWork it refers to a Performer of a Resource (e.g. a SoundRecording) expressing the MusicalWork.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ArtistRole">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ArtistRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ArtistRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="AudioCodecType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an AudioCodecType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:AudioCodecType">
+            <xs:attribute name="Version" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Identifier of the Version of the AudioCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the AudioCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the AudioCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="AvRating">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a rating for an audio-visual Creation.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="RatingText" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The text of the AvRating.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RatingAgency" type="mlc:RatingAgency">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an Organization that issues the AvRating.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RatingSchemeDescription"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:Description">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Description of the RatingText.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="CLine">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CLine.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Year" minOccurs="0" type="xs:gYear">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Year of the CLine.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLineCompany" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Name of the company releasing the Creation. This may be an owner or a licensee of the Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLineText" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The text of the CLine.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script of the CLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="CarrierType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CarrierType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:CarrierType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the CarrierType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the CarrierType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="CatalogNumber">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CatalogNumber.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="Namespace" type="xs:string" use="required">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the CatalogNumber. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="CdProtectionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CdProtectionType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:CdProtectionType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the CdProtectionType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the CdProtectionType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Comment">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an Comment.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Comment as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ContactId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of contact Identifiers of a Party.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="EmailAddress"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An EmailAddress of the Party.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PhoneNumber"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A PhoneNumber of the Party.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FaxNumber"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A FaxNumber of the Party.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ContainerFormat">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ContainerFormat.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ContainerFormat">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ContainerFormat. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ContainerFormat. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="CourtesyLine">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an CourtesyLine.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the CourtesyLine as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="CurrentTerritoryCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a TerritoryCode.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:CurrentTerritoryCode">
+            <xs:attribute name="IdentifierType" type="avs:TerritoryCodeType">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A standard used for the TerritoryCode. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the code is a TerritoryCode in accordance with ISO 3166-1 Alpha 2 standard (or Worldwide).</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="DdexDigitalSignature">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite placed at the beginning of each WsMessage providing information about the WsMessage such as MessageSender, MessageRecipient and a WsMessage creation time stamp.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="SignedInfo" type="ds:SignedInfoType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Element of type SignedInfoType.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SignatureValue" type="ds:SignatureValueType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Element of type SignatureValueType.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="KeyInfo" type="mlc:KeyInfo">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A KeyInfo Composite.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="Id" type="xs:ID">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">An XmlAttribute of type xs:ID.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="DelegatedUsageRights">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the kinds of usage for which rights have been delegated.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="UseType" maxOccurs="unbounded" type="mlc:UseType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the use for which rights are delegated.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="UserInterfaceType"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:UserInterfaceType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a physical interface by which a Consumer uses a Service or Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PeriodOfRightsDelegation" type="mlc:Period">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details about a Period of Time for which the delegation of usage rights applies. Periods are typically described by at least a StartDate or EndDate.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TerritoryOfRightsDelegation"
+                     maxOccurs="unbounded"
+                     type="mlc:CurrentTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Territory for which the delegation of usage rights applies.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Description">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an Description.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Description as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="EventDate">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="mlc:ddex_IsoDate">
+            <xs:attribute name="IsApproximate" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsBefore" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the Event being described occurred sometime before the reported Date (=true) or not (=false). This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsAfter" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the Event being described occurred sometime after the reported Date (=true) or not (=false). This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="TerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide”) is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LocationDescription" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="EventDateTime">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the DateTime and Place of an Event.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:dateTime">
+            <xs:attribute name="IsApproximate" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the reported DateTime is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsBefore" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the Event being described occurred sometime before the reported DateTime (=true) or not (=false). This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsAfter" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the Event being described occurred sometime after the reported DateTime (=true) or not (=false). This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="TerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide”) is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LocationDescription" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="FtpMessageHeader">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite placed at the beginning of each WsMessage providing information about the WsMessage such as MessageSender, MessageRecipient and a WsMessage creation time stamp.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="MessageSender" type="mlc:MessagingParty">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the MessageSender.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageRecipient" type="mlc:MessagingParty">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageCreatedDateTime" type="xs:dateTime">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The DateTime on which the Message was created (the only allowed format is ISO 8601:2004: YYYY-MM-DDThh:mm:ssTZD).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="HashSum" type="mlc:HashSum">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing a HashSum and information about the algorithm with which it has been generated.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="Signature" type="mlc:DdexDigitalSignature">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A digital signature in accordance with DDEX-DSIG.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="FulfillmentDate">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a FulfillmentDate.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="FulfillmentDate" type="mlc:ddex_IsoDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Date after which an end user can receive the Resource (in ISO 8601:2004 format: YYYY-MM-DD). If no FulfillmentDate is provided the FulfillmentDate is the StartDate of the respective Deal. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceReleaseReference" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of a Release for a Resource. This is a LocalReleaseAnchorReference starting with the letter R.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="R[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Genre">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Genre.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="GenreText" type="mlc:Description">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a Description of a genre or style (such as Musical, literary or audio-visual) with which a Creation is associated.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SubGenre" minOccurs="0" type="mlc:Description">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a Description of a secondary genre or style with which a Creation is associated.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Genre as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="GoverningAgreementType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a GoverningAgreementType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:GoverningAgreementType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the GoverningAgreementType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the GoverningAgreementType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="HashSum">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a HashSum and its governing algorithm.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="HashSum" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The value of the HashSum.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="HashSumAlgorithmType" type="mlc:HashSumAlgorithmType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Type of HashSumAlgorithm governing the HashSum.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="HashSumDataType" minOccurs="0" type="avs:BinaryDataType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The datatype of the HashSum.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="HashSumAlgorithmType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a HashSumAlgorithmType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:HashSumAlgorithmType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the HashSumAlgorithmType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the HashSumAlgorithmType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ICPN">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an ICPN.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="IsEan" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the ICPN is specifically an EAN (=true) or a UPC (=false). This is represented in an XML schema as an XML Attribute. This attribute is deprecated. DDEX advises that it will be removed at a future date and therefore recommends against using it.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="IndirectResourceContributor">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the Name, Identifier and role(s) of an indirect Contributor to a Resource.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice>
+            <xs:element name="PartyId" maxOccurs="unbounded" type="mlc:PartyId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:sequence>
+               <xs:element name="PartyName" maxOccurs="unbounded" type="mlc:PartyName">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyName(s).</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+               <xs:element name="PartyId"
+                           minOccurs="0"
+                           maxOccurs="unbounded"
+                           type="mlc:PartyId">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+            </xs:sequence>
+         </xs:choice>
+         <xs:element name="IndirectResourceContributorRole"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:MusicalWorkContributorRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a role played by the indirect Contributor.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Nationality"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ddexC_CurrentTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The nationality of the indirect Contributor.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="SequenceNumber" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The number indicating the order of the indirect ResourceContributor in a group of ResourceContributors that have contributed to a Resource. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="KeyInfo">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A KeyInfo Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="X509Data" type="mlc:X509Data">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An X509Data Composite.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="Id" type="xs:ID">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">An XmlAttribute of type xs:ID.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="Keywords">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Description containing Keywords.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Keywords as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="LabelName">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a LabelName.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the LabelName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LabelNameType" type="avs:LabelNameType">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Type of LabelName. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ReleaseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ReleaseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Membership">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a membership in a collective rights management organization.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Organization" type="mlc:PartyDescriptor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the collective rights management organization.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MembershipType" type="avs:MembershipType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of membership.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="StartDate" minOccurs="0" type="mlc:ddex_IsoDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The StartDate of the membership. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="EndDate" minOccurs="0" type="mlc:ddex_IsoDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The EndDate of the membership. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="MessageAuditTrail">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing information about Parties in between the original MessageSender and ultimate MessageRecipient.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="MessageAuditTrailEvent"
+                     maxOccurs="unbounded"
+                     type="mlc:MessageAuditTrailEvent">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Party handling the Message and the Time at which the handling took place.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the MessageAuditTrail as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="MessageAuditTrailEvent">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Party handling a Message and the Time at which the handling took place.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="MessagingPartyDescriptor" type="mlc:MessagingParty">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a MessagingParty.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DateTime" type="xs:dateTime">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The DateTime at which the Message was handled by the MessagingParty (the only allowed format is ISO 8601:2004: YYYY-MM-DDThh:mm:ssTZD).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="MessageHeader">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite placed at the beginning of each DdexMessage providing information about the Message, such as MessageSender, MessageRecipient and a Message creation time stamp.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="MessageThreadId" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A xs:string used to uniquely identify the thread of Messages of which the current Message is a part. The MessageThreadId shall be, in combination with the DdexPartyId (DPID) of the MessageSender, globally unique. Thus, a MessageSender shall never re-use a MessageThreadId. One example of such a 'thread' is the chain of NewReleaseMessages being sent from ReleaseCreator to wholesale ReleaseDistributor 1 to retail DSP when communicating information about the same Release(s). A common MessageThreadId will allow all these messages to be tied together.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A xs:string used to uniquely identify the current Message. The MessageId shall be, in combination with the DdexPartyId (DPID) of the MessageSender, globally unique. Thus, a MessageSender shall never re-use a MessageId.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageFileName" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The FileName, possibly including the FilePath, of the XML File containing the current Message.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageSender" type="mlc:MessagingParty">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the MessageSender.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SentOnBehalfOf" minOccurs="0" type="mlc:MessagingParty">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Party on whose behalf the Message is sent.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageRecipient"
+                     maxOccurs="unbounded"
+                     type="mlc:MessagingParty">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the MessageRecipient. Note that if multiple MessageRecipients are provided, all of them will be able to read this information.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageCreatedDateTime" type="xs:dateTime">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The DateTime on which the Message was created (the only allowed format is ISO 8601:2004: YYYY-MM-DDThh:mm:ssTZD).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageAuditTrail" minOccurs="0" type="mlc:MessageAuditTrail">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing information about Parties in between the original MessageSender and ultimate MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Comment" minOccurs="0" type="mlc:Comment">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a human-readable Comment about the Message.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageControlType"
+                     minOccurs="0"
+                     type="avs:MessageControlType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The indicator used to distinguish a live Message from a test Message.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the MessageHeader as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="MessageNotificationPeriod">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a reporting Period covered by a Message. It must contain at least one out of StartDate or EndDate. The StartDate must be earlier than the EndDate if both are provided.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="StartDate" type="mlc:ddex_IsoDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Date that marks the beginning of the Period (in ISO 8601:2004 format: YYYY-MM-DD). This cannot be a Date in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="EndDate" type="mlc:ddex_IsoDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Date that marks the end of the Period (in ISO 8601:2004 format: YYYY-MM-DD). This cannot be a Date in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="MessagingParty">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a MessagingParty.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="PartyId" maxOccurs="unbounded" type="mlc:PartyId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party handling the Message. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PartyName" minOccurs="0" type="mlc:PartyName">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PartyNames for the Party handling the Message.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TradingName" minOccurs="0" type="mlc:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a TradingName for the Party handling the Message.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the MessagingParty as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="MusicalWorkContributorRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a MusicalWorkContributorRole. Note: This can be used in a DdexMessage in relation to any Work, Performance or Fixation any of which may form the whole or part of the Resource itself. Example: if an 'AssociatedPerformer' is shown as a Contributor to a MusicalWork it refers to a performer of a Resource (e.g. a SoundRecording) expressing the MusicalWork.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:MusicalWorkContributorRole">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the MusicalWorkContributorRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the MusicalWorkContributorRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="MusicalWorkId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a MusicalWorkId.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ISWC" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISWC (International Standard Musical Work Code defined in ISO 15707) identifying the MusicalWork. An ISWC comprises three parts: the letter 'T', followed by nine digits and then one check digit. DDEX will enforce the syntax [a-zA-Z][0-9]{10} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="OpusNumber" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The MusicalWorkId identifying the MusicalWork within the catalog of its Composer (typically of classical music) as an opus number.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ComposerCatalogNumber"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWorkId identifying a MusicalWork within the catalog of its Composer (typically of classical music) according to a standardized numbering (e.g. 'K' numbers for Koechel's catalog of Mozart).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsReplaced" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="Name">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Name.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Name as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="PLine">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PLine.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Year" minOccurs="0" type="xs:gYear">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Year of the PLine.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLineCompany" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Name of the company releasing the Creation. This may be an owner or a licensee of the Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLineText" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The text of the PLine.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script of the PLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PLineType" type="avs:PLineType">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Type of PLine. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the PLine is a OriginalPLine.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="ParentalWarningType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ParentalWarningType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ParentalWarningType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ParentalWarningType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ParentalWarningType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="PartyDescriptor">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Party. Parties are typically described through Names and/or Identifiers.</xs:documentation>
+      </xs:annotation>
+      <xs:choice>
+         <xs:element name="PartyId" maxOccurs="unbounded" type="mlc:PartyId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:sequence>
+            <xs:element name="PartyName" maxOccurs="unbounded" type="mlc:PartyName">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyName(s).</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="PartyId"
+                        minOccurs="0"
+                        maxOccurs="unbounded"
+                        type="mlc:PartyId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+      </xs:choice>
+   </xs:complexType>
+   <xs:complexType name="PartyId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PartyId. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the PartyId if it belongs to a proprietary Party xs:ID scheme. If the PartyId is a DPID, the Namespace Element must not be used. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDPID" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the PartyId is a DPID (=true) or not (=false). This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsISNI" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the PartyId is an ISNI (=true) or not (=false). This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="PartyName">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PartyName. Name details for a Party typically either contain a FullName or a KeyName.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="FullName" type="mlc:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the complete Name of the Party, in its normal form of presentation (e.g. John H. Smith, Acme Music Inc, the Beatles).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FullNameAsciiTranscribed" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The FullName transcribed using 7-bit ASCII code.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FullNameIndexed" minOccurs="0" type="mlc:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the complete Name of the Party in the form in which it normally appears in an alphabetic index, with the KeyName first (e.g. Smith, John H.; Beatles, The).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NamesBeforeKeyName" minOccurs="0" type="mlc:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name(s) preceding the KeyName in the FullName (and that is placed after it in a FullNameIndexed). Examples: 'George' in 'George Michael'; 'John Fitzgerald' in 'John Fitzgerald Kennedy'. Not all PartyNames have a NamesBeforeKeyName (e.g. Madonna, EMI Music Inc).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="KeyName" minOccurs="0" type="mlc:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Part of a Name of the Party normally used to index an entry in an alphabetical list, such as 'Smith' (in John Smith) or 'Garcia Marquez' or 'Madonna' or 'Francis de Sales' (in Saint Francis de Sales). For persons, this normally corresponds to the 'family name' or names, which in Western name forms usually comes as a surname at the end of a FullName, and in Asian name forms often at the beginning of a FullName. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NamesAfterKeyName" minOccurs="0" type="mlc:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name(s) following the KeyName. Example:'Ibrahim' (in Anwar Ibrahim). This is common, e.g., in many Asian personal name forms where a FullName begins with the KeyName, which is followed by other names.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AbbreviatedName" minOccurs="0" type="mlc:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a short version of the PartyName (e.g. for use on devices with a small display).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the PartyName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="Percentage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PercentageRate.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:decimal">
+            <xs:attribute name="HasMaxValueOfOne" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Flag indicating whether a PercentageRate is given as a value in the range [0,1] (=true) instead of a value in the range [0,100] (=false). This is represented in an XML schema as an XML Attribute. Absence of this attribute is synonymous with false.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Performance">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Performance.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Territory" minOccurs="0" type="mlc:AllTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The territory of the Performance.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Date" minOccurs="0" type="mlc:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date of the Performance. This is a string with the syntax YYYY[-MM[-DD]]. The Place of the Performance should not be specified in the TerritoryCode and LocationDescription attributes. Instead, the sibling Territory element should be used.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Period">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details about a Period of Time. Periods are typically describedby at least a StartDate or EndDate (or StartDateTime or EndDateTime) where the StartDate(Time) and EndDate(Time) are included in the Period. Thus a one-day period can be described by using the same date in the StartDate and EndDate.</xs:documentation>
+      </xs:annotation>
+      <xs:choice>
+         <xs:sequence>
+            <xs:element name="StartDate" minOccurs="0" type="mlc:EventDate">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601:2004 format: YYYY-MM-DD). The StartDate must be earlier than the EndDate if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="EndDate" minOccurs="0" type="mlc:EventDate">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601:2004 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+         <xs:sequence>
+            <xs:element name="StartDateTime" minOccurs="0" type="mlc:EventDateTime">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the DateTime and Place of an Event that marks the beginning of the Period (in ISO 8601:2004 format: YYYY-DD-MMThh:mm:ss). The StartDateTime must be earlier than the EndDateTime if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="EndDateTime" minOccurs="0" type="mlc:EventDateTime">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the DateTime and Place of an Event that marks the end of the Period (in ISO 8601:2004 format: YYYY-DD-MMThh:mm:ss). The EndDateTime must not be earlier than the StartDateTime if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+      </xs:choice>
+   </xs:complexType>
+   <xs:complexType name="ProprietaryId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="Namespace" type="xs:string" use="required">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ProprietaryId. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Purpose">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Purpose.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:Purpose">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the Purpose. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the Purpose. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="RatingAgency">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a RatingAgency.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:RatingAgency">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the RatingAgency. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the RatingAgency. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ReferenceTitle">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ReferenceTitle.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TitleText" type="mlc:TitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the text of the ReferenceTitle.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SubTitle" minOccurs="0" type="mlc:SubTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a SubTitle of the ReferenceTitle, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets (where the SubTitle is called Version Title).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the ReferenceTitle as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="ReleaseId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ReleaseId. If available, a GRid should always to be used. If the Release contains only one SoundRecording, the ISRC of the SoundRecording may be used instead. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="GRid" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The GRid identifying the Release. This is the preferred Element and is mandatory if a GRid is available. A GRid comprises four parts: the xs:string 'A1', followed by five alphanumeric characters, ten alphanumeric characters and and one alphanumeric character. DDEX will enforce the syntax [a-zA-Z0-9]{18} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ISRC" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISRC (International Standard Recording Code as defined in  ISO 3901) used as proxy for identification of the Release. Only applicable when the Release only contains one SoundRecording or one MusicalWorkVideo. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ICPN" minOccurs="0" type="mlc:ICPN">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the ICPN used as proxy for identification of the Release. Only applicable when the Release is an abstraction of a complete PhysicalProduct. An ICPN comprises 12 or 13 digits, depending whether it is an EAN (13) or a UPC (12). DDEX will enforce the syntax [0-9]{12,13} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CatalogNumber" minOccurs="0" type="mlc:CatalogNumber">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CatalogNumber of the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsReplaced" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="ReleaseType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ReleaseType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ReleaseType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ReleaseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ReleaseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ResourceContainedResourceReference">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceContainedResourceReference for the case where one Resource contains another one.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ResourceContainedResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="DurationUsed" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The total Duration of the Resource that has been used in a specified context (this may be less than the total Duration of the Resource) (using the ISO 8601:2004 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="StartPoint" minOccurs="0" type="xs:decimal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The start point of the preview given in seconds from the start of the referenced Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Purpose" minOccurs="0" type="mlc:Purpose">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Purpose of the usage.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ResourceContainedResourceReferenceList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more ResourceContainedResourceReferences. </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ResourceContainedResourceReference"
+                     maxOccurs="unbounded"
+                     type="mlc:ResourceContainedResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceContainedResourceReference.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ResourceContributorRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceContributorRole. Note: This can be used in a DdexMessage in relation to any Work, Performance or Fixation any of which may form the whole or part of the Resource itself.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ResourceContributorRole">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ResourceContributorRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ResourceContributorRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ResourceMusicalWorkReference">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing a ResourceMusicalWorkReference.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="SequenceNumber" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number indicating the order of the MusicalWork in a group of MusicalWorks within a Medley, SoundRecording or other Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DurationUsed" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The total Duration of the MusicalWork that has been used in a specified context (this may be less than the total Duration of the MusicalWork) (using the ISO 8601:2004 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsFragment" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the MusicalWork is a Fragment (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceMusicalWorkReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a MusicalWork (specific to this Message). This is a LocalMusicalWorkAnchorReference starting with the letter W.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="W[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ResourceMusicalWorkReferenceList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing a list of ResourceMusicalWorkReferences.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ResourceMusicalWorkReference"
+                     maxOccurs="unbounded"
+                     type="mlc:ResourceMusicalWorkReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a ResourceMusicalWorkReference for a MusicalWork (specific to this Message).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="RightsAgreementId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of Identifiers of a License, Claim, RightShare or contract.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="MWLI"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWork License Identifier identifying a License. If the Composite is meant to describe a Claim, RightShare or contract, then the License relates to that Claim, RightShare or contract. A MWLI comprises four parts: one of the xs:strings 'M1' or 'M2' or 'M3' or 'M4', followed by five alphanumeric characters, ten alphanumeric characters and one alphanumeric check character.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the License, Claim, RightShare or contract.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="SoundRecordingCollectionReference">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecordingCollectionReference.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="SequenceNumber" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number indicating the order of the Collection in a group of Collections within a Medley, SoundRecording or other Collection.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SoundRecordingCollectionReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a Collection (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X. The referenced Collection has to be of CollectionType Series, Season or Episode.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="X[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="StartTime" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The start time of the Creation, measured from the start of the Resource from which the CueSheet is referenced (using the ISO 8601:2004 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Duration" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Duration of the use of the Creation that is referenced in the CueCreationReference (using the ISO 8601:2004 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="EndTime" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The end time of the Creation, measured from the start of the Resource from which the CueSheet is referenced (using the ISO 8601:2004 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseResourceType"
+                     minOccurs="0"
+                     type="avs:ReleaseResourceType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of Collection in the context of a Video. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="SoundRecordingCollectionReferenceList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing a list of SoundRecordingCollectionReferences.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="NumberOfCollections" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of referenced Collections (typically Chapters).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SoundRecordingCollectionReference"
+                     maxOccurs="unbounded"
+                     type="mlc:SoundRecordingCollectionReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a SoundRecordingCollectionReference for a Collection (specific to this Message).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="SoundRecordingId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of SoundRecordingIds.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ISRC" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISRC (International Standard Recording Code as defined in  ISO 3901) for the SoundRecording. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CatalogNumber" minOccurs="0" type="mlc:CatalogNumber">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CatalogNumber of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the SoundRecording (usually one per society involved in the messaging).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsReplaced" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="SoundRecordingType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecordingType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:SoundRecordingType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the SoundRecordingType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the SoundRecordingType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="SubTitle">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SubTitle, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the SubTitle as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Synopsis">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Synopsis.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Synopsis as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Title">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Title.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TitleText" type="mlc:TitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the text of the Title.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SubTitle"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:TypedSubTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="TitleType" type="avs:TitleType">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Type of the Title which defines its origin or the function it fulfils in relation to a Creation. Note: A Title may fulfil more than one role. Example: 'Help' may be both the OriginalTitle and the DisplayTitle for the well-known Beatles song. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="TitleText">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a TitleText.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the TitleText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="TypedSubTitle">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SubTitle, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the SubTitle as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-scipt][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="SubTitleType" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Type of the SubTitle which defines its origin or the function it fulfils. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="UseType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a UseType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:UseType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the UseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the UseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="UserInterfaceType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a UserInterfaceType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:UserInterfaceType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the UserInterfaceType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the UserInterfaceType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="VideoCodecType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a VideoCodecType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:VideoCodecType">
+            <xs:attribute name="Version" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Identifier of the Version of the VideoCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the VideoCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the VideoCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="VideoId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of Identifiers of a Video.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ISRC" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISRC (International Standard Recording Code as defined in  ISO 3901) for the Video. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ISAN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISAN (International Standard Audiovisual Number as defined in ISO 15706) for the Video. An ISAN comprises four blocks of four hexadecimal charaters followed by a check character. DDEX will enforce the syntax [A-F0-9]{12} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VISAN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The V-ISAN (Version Identifier of a International Standard Audiovisual Number as defined in ISO 15706-2) for the Video. A V-ISAN comprises four blocks of four hexadecimal charaters followed by a check character, followed by two further blocks of four hexadecimal characters, followed by a further check character. DDEX will enforce the syntax [A-F0-9]{24} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CatalogNumber" minOccurs="0" type="mlc:CatalogNumber">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CatalogNumber of the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="mlc:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the Video (usually one per society involved in the messaging).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="EIDR"
+                     minOccurs="0"
+                     maxOccurs="unbounded"
+                     type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Identifier of the Video assigned by the Entertainment Identifier Registry Association (EIDR).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsReplaced" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="VideoType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a VideoType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:VideoType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the VideoType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the VideoType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="X509Data">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">An X509Data Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence maxOccurs="unbounded">
+         <xs:choice>
+            <xs:element name="X509IssuerSerial" type="ds:X509IssuerSerialType">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">An Element of type X509IssuerSerialType.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="X509SKI" type="xs:base64Binary">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">An Element of type xs:base64Binary.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="X509SubjectName" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">An Element of type xs:string.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="X509Certificate" type="xs:base64Binary">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">An Element of type xs:base64Binary.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="X509CRL" type="xs:base64Binary">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">An Element of type xs:base64Binary.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="PartyId" type="mlc:PartyId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, Producers or other Creators.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax"/>
+         </xs:choice>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:simpleType name="ddexC_CurrentTerritoryCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a TerritoryCode.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="IdentifierType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A standard used for the TerritoryCode. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the code is a TerritoryCode in accordance with ISO 3166-1 Alpha 2 standard (or Worldwide).</xs:documentation>
+            </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ddex_IsoDate">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Date represented in ISO 8601:2004 format: YYYY[-MM[-DD]].</xs:documentation>
+         <xs:documentation source="ddex:Comment">Format: A Date represented as a calendar Year, Month or Day (in ISO 8601:2004 format: YYYY, YYYY-MM or YYYY-MM-DD).</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:pattern value="[0-9]{4}(-[0-9]{2}){0,1}(-[0-9]{2}){0,1}"/>
+      </xs:restriction>
+   </xs:simpleType>
+</xs:schema>

--- a/spec/xml_spec.rb
+++ b/spec/xml_spec.rb
@@ -6,6 +6,9 @@ describe XsdReader do
     XsdReader::XML.new(:xsd_file => File.expand_path(File.join(File.dirname(__FILE__), 'examples', 'ddex-v36', 'ddex-ern-v36.xsd')))
   }
 
+  let(:mlc_reader){
+    XsdReader::XML.new(:xsd_file => File.expand_path(File.join(File.dirname(__FILE__), 'examples', 'ddex-mlc', 'music-licensing-companies.xsd')))
+  }
   describe XsdReader::XML do
     it "gives a schema_node" do
       expect(reader.schema_node.name).to eq 'schema'
@@ -14,6 +17,10 @@ describe XsdReader do
 
     it "gives a schema reader" do
       expect(reader.schema.class).to eq XsdReader::Schema
+    end
+
+    it "reads referenced schemas which bind the xmlschema namespace to the root namespace instead of xs" do
+      expect(mlc_reader['DeclarationOfSoundRecordingRightsClaimMessage'].elements.first.name).to eq 'MessageHeader'
     end
 
     it "gives an elements shortcut to its schema's shortcuts" do

--- a/xsd-reader.gemspec
+++ b/xsd-reader.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "xsd-reader"
-  s.version = '0.3.0'
+  s.version = '0.4.0'
   s.files = `git ls-files`.split($/)
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 


### PR DESCRIPTION
(in this case the xmldsig xsd referenced from mlc)